### PR TITLE
Fix-ui-mantine

### DIFF
--- a/.changeset/forty-garlics-drum.md
+++ b/.changeset/forty-garlics-drum.md
@@ -1,0 +1,5 @@
+---
+"@bonfhir/ui-mantine": patch
+---
+
+Fix `FhirTable` header no-wrap to prevent orphaned sort button

--- a/.changeset/rare-buttons-explain.md
+++ b/.changeset/rare-buttons-explain.md
@@ -1,0 +1,5 @@
+---
+"@bonfhir/ui-mantine": patch
+---
+
+Fix a bug in `FhirTable` rendererProps for td styling

--- a/.changeset/rich-boats-return.md
+++ b/.changeset/rich-boats-return.md
@@ -1,0 +1,5 @@
+---
+"@bonfhir/ui-mantine": patch
+---
+
+Add `theadPrefix` and `headerCell` to `FhirTable` to allow more customization of the table header

--- a/apps/sample-ehr/src/pages/patients/index.tsx
+++ b/apps/sample-ehr/src/pages/patients/index.tsx
@@ -259,6 +259,24 @@ function PatientsList(): ReactElement {
                   ),
                 },
                 {
+                  key: "passport",
+                  title: "Passport",
+                  render: (row) => (
+                    <FhirValue
+                      type="Identifier"
+                      value={row.identifier}
+                      options={{
+                        max: 1,
+                        systemFilterOrder: [
+                          "http://standardhealthrecord.org/fhir/StructureDefinition/passportNumber",
+                        ],
+                        style: "value",
+                        default: "Unknown",
+                      }}
+                    />
+                  ),
+                },
+                {
                   key: "_lastUpdated",
                   title: "Last Updated",
                   sortable: true,

--- a/packages/ui-mantine/src/r4b/data-display/fhir-table.tsx
+++ b/packages/ui-mantine/src/r4b/data-display/fhir-table.tsx
@@ -102,22 +102,26 @@ function MantineFhirTableHeader({
     >
       <Group
         position="apart"
+        spacing={0}
+        noWrap={true}
         sx={{
           fontSize: "inherit",
           fontWeight: "inherit",
           color: "inherit",
         }}
       >
-        {column.title}
-        {parsedSort?.columnKey === column.key ? (
-          parsedSort.desc ? (
-            <IconChevronDown />
+        <>{column.title}</>
+        <>
+          {parsedSort?.columnKey === column.key ? (
+            parsedSort.desc ? (
+              <IconChevronDown />
+            ) : (
+              <IconChevronUp />
+            )
           ) : (
-            <IconChevronUp />
-          )
-        ) : (
-          <IconSelector />
-        )}
+            <IconSelector />
+          )}
+        </>
       </Group>
     </UnstyledButton>
   ) : (

--- a/packages/ui-mantine/src/r4b/data-display/fhir-table.tsx
+++ b/packages/ui-mantine/src/r4b/data-display/fhir-table.tsx
@@ -130,7 +130,7 @@ function propsOrFunction<TProps extends object>(
   ...arg: any[]
 ): TProps | null | undefined {
   if (typeof value === "function") {
-    return value(arg);
+    return value(...arg);
   }
 
   return value;

--- a/packages/ui-mantine/src/r4b/data-display/fhir-table.tsx
+++ b/packages/ui-mantine/src/r4b/data-display/fhir-table.tsx
@@ -11,7 +11,12 @@ import {
   IconChevronUp,
   IconSelector,
 } from "@tabler/icons-react";
-import { DetailedHTMLProps, HTMLAttributes, ReactElement } from "react";
+import {
+  DetailedHTMLProps,
+  HTMLAttributes,
+  ReactElement,
+  createElement,
+} from "react";
 
 export function MantineFhirTable(
   props: FhirTableRendererProps<MantineFhirTableProps>,
@@ -21,17 +26,23 @@ export function MantineFhirTable(
   return (
     <Table {...props.rendererProps?.table}>
       <thead {...props.rendererProps?.thead}>
+        {props.rendererProps?.theadPrefix
+          ? createElement(props.rendererProps.theadPrefix)
+          : null}
         <tr>
           {props.columns.map((column) => (
             <th
               key={column.key}
               {...propsOrFunction(props.rendererProps?.th, column)}
             >
-              <MantineFhirTableHeader
-                column={column}
-                parsedSort={props.parsedSort}
-                onSortChange={props.onSortChange}
-              />
+              {createElement(
+                props.rendererProps?.headerCell ?? MantineFhirTableHeader,
+                {
+                  column,
+                  parsedSort: props.parsedSort,
+                  onSortChange: props.onSortChange,
+                },
+              )}
             </th>
           ))}
         </tr>
@@ -79,15 +90,17 @@ export function MantineFhirTable(
   );
 }
 
+export interface MantineFhirTableHeaderProps {
+  column: FhirTableColumn<any>;
+  parsedSort: FhirTableRendererProps["parsedSort"];
+  onSortChange: FhirTableRendererProps["onSortChange"];
+}
+
 function MantineFhirTableHeader({
   column,
   parsedSort,
   onSortChange,
-}: {
-  column: FhirTableColumn<any>;
-  parsedSort: FhirTableRendererProps["parsedSort"];
-  onSortChange: FhirTableRendererProps["onSortChange"];
-}) {
+}: MantineFhirTableHeaderProps) {
   return column.sortable ? (
     <UnstyledButton
       onClick={() => {
@@ -149,6 +162,8 @@ export interface MantineFhirTableProps {
       >
     | null
     | undefined;
+  theadPrefix?: () => ReactElement;
+  headerCell?: (props: MantineFhirTableHeaderProps) => ReactElement;
   tbody?:
     | DetailedHTMLProps<
         HTMLAttributes<HTMLTableSectionElement>,

--- a/packages/ui-mantine/src/r5/data-display/fhir-table.tsx
+++ b/packages/ui-mantine/src/r5/data-display/fhir-table.tsx
@@ -102,22 +102,26 @@ function MantineFhirTableHeader({
     >
       <Group
         position="apart"
+        spacing={0}
+        noWrap={true}
         sx={{
           fontSize: "inherit",
           fontWeight: "inherit",
           color: "inherit",
         }}
       >
-        {column.title}
-        {parsedSort?.columnKey === column.key ? (
-          parsedSort.desc ? (
-            <IconChevronDown />
+        <>{column.title}</>
+        <>
+          {parsedSort?.columnKey === column.key ? (
+            parsedSort.desc ? (
+              <IconChevronDown />
+            ) : (
+              <IconChevronUp />
+            )
           ) : (
-            <IconChevronUp />
-          )
-        ) : (
-          <IconSelector />
-        )}
+            <IconSelector />
+          )}
+        </>
       </Group>
     </UnstyledButton>
   ) : (

--- a/packages/ui-mantine/src/r5/data-display/fhir-table.tsx
+++ b/packages/ui-mantine/src/r5/data-display/fhir-table.tsx
@@ -130,7 +130,7 @@ function propsOrFunction<TProps extends object>(
   ...arg: any[]
 ): TProps | null | undefined {
   if (typeof value === "function") {
-    return value(arg);
+    return value(...arg);
   }
 
   return value;

--- a/packages/ui-mantine/src/r5/data-display/fhir-table.tsx
+++ b/packages/ui-mantine/src/r5/data-display/fhir-table.tsx
@@ -11,7 +11,12 @@ import {
   IconChevronUp,
   IconSelector,
 } from "@tabler/icons-react";
-import { DetailedHTMLProps, HTMLAttributes, ReactElement } from "react";
+import {
+  DetailedHTMLProps,
+  HTMLAttributes,
+  ReactElement,
+  createElement,
+} from "react";
 
 export function MantineFhirTable(
   props: FhirTableRendererProps<MantineFhirTableProps>,
@@ -21,17 +26,23 @@ export function MantineFhirTable(
   return (
     <Table {...props.rendererProps?.table}>
       <thead {...props.rendererProps?.thead}>
+        {props.rendererProps?.theadPrefix
+          ? createElement(props.rendererProps.theadPrefix)
+          : null}
         <tr>
           {props.columns.map((column) => (
             <th
               key={column.key}
               {...propsOrFunction(props.rendererProps?.th, column)}
             >
-              <MantineFhirTableHeader
-                column={column}
-                parsedSort={props.parsedSort}
-                onSortChange={props.onSortChange}
-              />
+              {createElement(
+                props.rendererProps?.headerCell ?? MantineFhirTableHeader,
+                {
+                  column,
+                  parsedSort: props.parsedSort,
+                  onSortChange: props.onSortChange,
+                },
+              )}
             </th>
           ))}
         </tr>
@@ -79,15 +90,17 @@ export function MantineFhirTable(
   );
 }
 
+export interface MantineFhirTableHeaderProps {
+  column: FhirTableColumn<any>;
+  parsedSort: FhirTableRendererProps["parsedSort"];
+  onSortChange: FhirTableRendererProps["onSortChange"];
+}
+
 function MantineFhirTableHeader({
   column,
   parsedSort,
   onSortChange,
-}: {
-  column: FhirTableColumn<any>;
-  parsedSort: FhirTableRendererProps["parsedSort"];
-  onSortChange: FhirTableRendererProps["onSortChange"];
-}) {
+}: MantineFhirTableHeaderProps) {
   return column.sortable ? (
     <UnstyledButton
       onClick={() => {
@@ -149,6 +162,8 @@ export interface MantineFhirTableProps {
       >
     | null
     | undefined;
+  theadPrefix?: () => ReactElement;
+  headerCell?: (props: MantineFhirTableHeaderProps) => ReactElement;
   tbody?:
     | DetailedHTMLProps<
         HTMLAttributes<HTMLTableSectionElement>,


### PR DESCRIPTION
This PR includes a few fixes and extension points for `ui-mantine`:
 - Fix a bug in `FhirTable` rendererProps for td styling
 - Fix `FhirTable` header no-wrap to prevent orphaned sort button
 - Add `theadPrefix` and `headerCell` to `FhirTable` to allow more customization of the table header