### PR TITLE
QOL improvements: `isReferenceOf`, subscription typing

### DIFF
--- a/.changeset/dirty-doors-rule.md
+++ b/.changeset/dirty-doors-rule.md
@@ -1,0 +1,5 @@
+---
+"@bonfhir/core": minor
+---
+
+Add `isReferenceOf` helper

--- a/.changeset/short-parrots-sleep.md
+++ b/.changeset/short-parrots-sleep.md
@@ -1,0 +1,5 @@
+---
+"@bonfhir/subscriptions": patch
+---
+
+Update to FhirSubscription resource type -> Retrieved<TResource>

--- a/apps/sample-ehr/src/config.tsx
+++ b/apps/sample-ehr/src/config.tsx
@@ -2,12 +2,10 @@ export const Config = {
   public: {
     fhirUrl:
       process.env.NEXT_PUBLIC_FHIR_URL || "http://localhost:8103/fhir/R4/",
-    logoutUrl:
-      process.env.NEXT_PUBLIC_AUTH_LOGOUT ||
-      "http://localhost:8103/oauth2/logout",
   },
   server: {
     authServerUrl: process.env.AUTH_SERVER_URL || "http://localhost:8103",
+    logoutUrl: process.env.LOGOUT_URL || "http://localhost:8103/oauth2/logout",
     authClientId:
       process.env.AUTH_CLIENT_ID || "f54370de-eaf3-4d81-a17e-24860f667912",
     authClientSecret:

--- a/apps/sample-ehr/src/next-auth.d.ts
+++ b/apps/sample-ehr/src/next-auth.d.ts
@@ -1,13 +1,19 @@
+import { Practitioner, Reference, RelatedPerson } from "@bonfhir/core/r4b";
 import "next-auth";
 
 declare module "next-auth" {
-  interface Profile {
-    id: string;
-    fhirUser: string;
+  interface Account {
+    profile: {
+      reference: string;
+      display: string;
+    };
   }
 
   interface Session {
-    //user: {} & DefaultSession["user"];
+    user: {
+      id: string;
+      profile: Reference<Practitioner | RelatedPerson>;
+    };
     accessToken: string;
   }
 }
@@ -15,5 +21,9 @@ declare module "next-auth" {
 declare module "next-auth/jwt" {
   interface JWT {
     accessToken: string;
+    profile: {
+      reference: string;
+      display: string;
+    };
   }
 }

--- a/apps/sample-ehr/src/pages/_app.tsx
+++ b/apps/sample-ehr/src/pages/_app.tsx
@@ -5,7 +5,13 @@ import { FetchFhirClient, FhirClient, Formatter } from "@bonfhir/core/r4b";
 import { FhirQueryProvider } from "@bonfhir/query/r4b";
 import { MantineRenderer } from "@bonfhir/ui-mantine/r4b";
 import { FhirUIProvider } from "@bonfhir/ui/r4b";
-import { AppShell, MantineProvider, MantineThemeOverride } from "@mantine/core";
+import {
+  AppShell,
+  Center,
+  Loader,
+  MantineProvider,
+  MantineThemeOverride,
+} from "@mantine/core";
 import { ReactQueryDevtools } from "@tanstack/react-query-devtools";
 import { SessionProvider, signIn, useSession } from "next-auth/react";
 import { AppProps } from "next/app";
@@ -101,7 +107,7 @@ function WithAuth(props: PropsWithChildren) {
   }, [status]);
 
   useEffect(() => {
-    if (session) {
+    if (session?.accessToken) {
       setFhirClient(
         new FetchFhirClient({
           baseUrl: Config.public.fhirUrl,
@@ -111,8 +117,14 @@ function WithAuth(props: PropsWithChildren) {
     }
   }, [session]);
 
-  if (!session || !fhirClient) {
-    return;
+  if (status !== "authenticated" || !session?.accessToken || !fhirClient) {
+    return (
+      <AppShell>
+        <Center h="100%">
+          <Loader />
+        </Center>
+      </AppShell>
+    );
   }
 
   return (

--- a/apps/sample-ehr/src/pages/api/auth/[...nextauth].ts
+++ b/apps/sample-ehr/src/pages/api/auth/[...nextauth].ts
@@ -14,7 +14,6 @@ export default NextAuth({
       profile: (profile) => {
         return {
           id: profile.sub,
-          fhirUser: profile.fhirUser,
         };
       },
     },
@@ -24,12 +23,29 @@ export default NextAuth({
     async jwt({ token, account }) {
       if (account) {
         token.accessToken = account.access_token!;
+        token.profile = account.profile;
       }
       return token;
     },
     async session({ session, token }) {
       session.accessToken = token.accessToken;
+      session.user = {
+        id: token.sub!,
+        profile: token.profile,
+      };
       return session;
+    },
+  },
+  events: {
+    async signOut({ token }) {
+      await fetch(Config.server.logoutUrl, {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+          Authorization: `Bearer ${token.accessToken}`,
+        },
+        body: JSON.stringify({}),
+      });
     },
   },
 });

--- a/apps/sample-ehr/src/pages/logout.tsx
+++ b/apps/sample-ehr/src/pages/logout.tsx
@@ -1,24 +1,15 @@
-import { Config } from "@/config";
 import { useFhirClientQueryContext } from "@bonfhir/query/r4b";
 import { signOut, useSession } from "next-auth/react";
 import { useRouter } from "next/router";
 import { useEffect } from "react";
 
 export default function Logout() {
-  const { data: session, status } = useSession();
+  const { status } = useSession();
   const fhirClientQueryContext = useFhirClientQueryContext(undefined);
   const router = useRouter();
 
   useEffect(() => {
     if (status === "authenticated") {
-      fetch(Config.public.logoutUrl, {
-        method: "POST",
-        headers: {
-          "Content-Type": "application/json",
-          Authorization: `Bearer ${session.accessToken}`,
-        },
-        body: JSON.stringify({}),
-      });
       fhirClientQueryContext.queryClient.clear();
       signOut({ callbackUrl: "/" });
     } else {

--- a/packages/core/src/r4b/builders.test.ts
+++ b/packages/core/src/r4b/builders.test.ts
@@ -1,4 +1,4 @@
-import { build, codeableConcept, id } from "./builders";
+import { build, codeableConcept, id, isReferenceOf } from "./builders";
 import { DomainResourceTypes } from "./fhir-types.codegen";
 
 describe("builders", () => {
@@ -73,5 +73,32 @@ describe("builders", () => {
     ])("%p => %p", (value, expected) => {
       expect(codeableConcept(value)).toEqual(expected);
     });
+  });
+
+  describe("isReferenceOf", () => {
+    it.each([
+      [undefined, "Patient", false],
+      ["Organization/123", "Patient", false],
+      ["Patient/123", "Patient", true],
+    ] as const)(
+      `check reference of %p => %p = %p`,
+      (reference, type, expected) => {
+        expect(isReferenceOf({ reference: reference }, type)).toEqual(expected);
+      },
+    );
+
+    it.each([
+      [undefined, "Patient", "Organization", false],
+      ["Organization/123", "Patient", "Organization", true],
+      ["Patient/123", "Patient", "Organization", true],
+      ["Medication/123", "Patient", "Organization", false],
+    ] as const)(
+      `check reference of multiple %p => %p = %p`,
+      (reference, type1, type2, expected) => {
+        expect(isReferenceOf({ reference: reference }, type1, type2)).toEqual(
+          expected,
+        );
+      },
+    );
   });
 });

--- a/packages/core/src/r4b/builders.ts
+++ b/packages/core/src/r4b/builders.ts
@@ -1,9 +1,11 @@
 import {
   AnyDomainResourceType,
   AnyResource,
+  AnyResourceType,
   CodeableConcept,
   Coding,
   ExtractDomainResource,
+  ExtractResource,
   Reference,
   Retrieved,
 } from "./fhir-types.codegen";
@@ -97,4 +99,87 @@ export function canonical(
   return resource.version
     ? `${resource.url}|${resource.version}`
     : resource.url;
+}
+
+/**
+ * Check whether a reference is a reference to a specific resource type, and assert the strong Reference type.
+ */
+export function isReferenceOf<TResourceType extends AnyResourceType>(
+  reference: Reference | null | undefined,
+  resourceType: TResourceType,
+): reference is Reference<ExtractResource<TResourceType>>;
+export function isReferenceOf<
+  TResourceType extends AnyResourceType,
+  TResourceType2 extends AnyResourceType,
+>(
+  reference: Reference | null | undefined,
+  resourceType: TResourceType,
+  resourceType2: TResourceType2,
+): reference is Reference<
+  ExtractResource<TResourceType> | ExtractResource<TResourceType2>
+>;
+export function isReferenceOf<
+  TResourceType extends AnyResourceType,
+  TResourceType2 extends AnyResourceType,
+  TResourceType3 extends AnyResourceType,
+>(
+  reference: Reference | null | undefined,
+  resourceType: TResourceType,
+  resourceType2: TResourceType2,
+  resourceType3: TResourceType3,
+): reference is Reference<
+  | ExtractResource<TResourceType>
+  | ExtractResource<TResourceType2>
+  | ExtractResource<TResourceType3>
+>;
+export function isReferenceOf<
+  TResourceType extends AnyResourceType,
+  TResourceType2 extends AnyResourceType,
+  TResourceType3 extends AnyResourceType,
+  TResourceType4 extends AnyResourceType,
+>(
+  reference: Reference | null | undefined,
+  resourceType: TResourceType,
+  resourceType2: TResourceType2,
+  resourceType3: TResourceType3,
+  resourceType4: TResourceType4,
+): reference is Reference<
+  | ExtractResource<TResourceType>
+  | ExtractResource<TResourceType2>
+  | ExtractResource<TResourceType3>
+  | ExtractResource<TResourceType4>
+>;
+export function isReferenceOf<
+  TResourceType extends AnyResourceType,
+  TResourceType2 extends AnyResourceType,
+  TResourceType3 extends AnyResourceType,
+  TResourceType4 extends AnyResourceType,
+  TResourceType5 extends AnyResourceType,
+>(
+  reference: Reference | null | undefined,
+  resourceType: TResourceType,
+  resourceType2: TResourceType2,
+  resourceType3: TResourceType3,
+  resourceType4: TResourceType4,
+  resourceType5: TResourceType5,
+): reference is Reference<
+  | ExtractResource<TResourceType>
+  | ExtractResource<TResourceType2>
+  | ExtractResource<TResourceType3>
+  | ExtractResource<TResourceType4>
+  | ExtractResource<TResourceType5>
+>;
+export function isReferenceOf<TResourceType extends AnyResourceType>(
+  reference: Reference | null | undefined,
+  ...resourceType: TResourceType[]
+): boolean {
+  if (!reference?.reference) {
+    return false;
+  }
+  for (const rt of resourceType) {
+    if (reference.reference.startsWith(`${rt}/`)) {
+      return true;
+    }
+  }
+  return false;
 }

--- a/packages/core/src/r5/builders.test.ts
+++ b/packages/core/src/r5/builders.test.ts
@@ -1,4 +1,4 @@
-import { build, codeableConcept, id } from "./builders";
+import { build, codeableConcept, id, isReferenceOf } from "./builders";
 import { DomainResourceTypes } from "./fhir-types.codegen";
 
 describe("builders", () => {
@@ -73,5 +73,32 @@ describe("builders", () => {
     ])("%p => %p", (value, expected) => {
       expect(codeableConcept(value)).toEqual(expected);
     });
+  });
+
+  describe("isReferenceOf", () => {
+    it.each([
+      [undefined, "Patient", false],
+      ["Organization/123", "Patient", false],
+      ["Patient/123", "Patient", true],
+    ] as const)(
+      `check reference of %p => %p = %p`,
+      (reference, type, expected) => {
+        expect(isReferenceOf({ reference: reference }, type)).toEqual(expected);
+      },
+    );
+
+    it.each([
+      [undefined, "Patient", "Organization", false],
+      ["Organization/123", "Patient", "Organization", true],
+      ["Patient/123", "Patient", "Organization", true],
+      ["Medication/123", "Patient", "Organization", false],
+    ] as const)(
+      `check reference of multiple %p => %p = %p`,
+      (reference, type1, type2, expected) => {
+        expect(isReferenceOf({ reference: reference }, type1, type2)).toEqual(
+          expected,
+        );
+      },
+    );
   });
 });

--- a/packages/core/src/r5/builders.ts
+++ b/packages/core/src/r5/builders.ts
@@ -1,9 +1,11 @@
 import {
   AnyDomainResourceType,
   AnyResource,
+  AnyResourceType,
   CodeableConcept,
   Coding,
   ExtractDomainResource,
+  ExtractResource,
   Reference,
   Retrieved,
 } from "./fhir-types.codegen";
@@ -97,4 +99,87 @@ export function canonical(
   return resource.version
     ? `${resource.url}|${resource.version}`
     : resource.url;
+}
+
+/**
+ * Check whether a reference is a reference to a specific resource type, and assert the strong Reference type.
+ */
+export function isReferenceOf<TResourceType extends AnyResourceType>(
+  reference: Reference | null | undefined,
+  resourceType: TResourceType,
+): reference is Reference<ExtractResource<TResourceType>>;
+export function isReferenceOf<
+  TResourceType extends AnyResourceType,
+  TResourceType2 extends AnyResourceType,
+>(
+  reference: Reference | null | undefined,
+  resourceType: TResourceType,
+  resourceType2: TResourceType2,
+): reference is Reference<
+  ExtractResource<TResourceType> | ExtractResource<TResourceType2>
+>;
+export function isReferenceOf<
+  TResourceType extends AnyResourceType,
+  TResourceType2 extends AnyResourceType,
+  TResourceType3 extends AnyResourceType,
+>(
+  reference: Reference | null | undefined,
+  resourceType: TResourceType,
+  resourceType2: TResourceType2,
+  resourceType3: TResourceType3,
+): reference is Reference<
+  | ExtractResource<TResourceType>
+  | ExtractResource<TResourceType2>
+  | ExtractResource<TResourceType3>
+>;
+export function isReferenceOf<
+  TResourceType extends AnyResourceType,
+  TResourceType2 extends AnyResourceType,
+  TResourceType3 extends AnyResourceType,
+  TResourceType4 extends AnyResourceType,
+>(
+  reference: Reference | null | undefined,
+  resourceType: TResourceType,
+  resourceType2: TResourceType2,
+  resourceType3: TResourceType3,
+  resourceType4: TResourceType4,
+): reference is Reference<
+  | ExtractResource<TResourceType>
+  | ExtractResource<TResourceType2>
+  | ExtractResource<TResourceType3>
+  | ExtractResource<TResourceType4>
+>;
+export function isReferenceOf<
+  TResourceType extends AnyResourceType,
+  TResourceType2 extends AnyResourceType,
+  TResourceType3 extends AnyResourceType,
+  TResourceType4 extends AnyResourceType,
+  TResourceType5 extends AnyResourceType,
+>(
+  reference: Reference | null | undefined,
+  resourceType: TResourceType,
+  resourceType2: TResourceType2,
+  resourceType3: TResourceType3,
+  resourceType4: TResourceType4,
+  resourceType5: TResourceType5,
+): reference is Reference<
+  | ExtractResource<TResourceType>
+  | ExtractResource<TResourceType2>
+  | ExtractResource<TResourceType3>
+  | ExtractResource<TResourceType4>
+  | ExtractResource<TResourceType5>
+>;
+export function isReferenceOf<TResourceType extends AnyResourceType>(
+  reference: Reference | null | undefined,
+  ...resourceType: TResourceType[]
+): boolean {
+  if (!reference?.reference) {
+    return false;
+  }
+  for (const rt of resourceType) {
+    if (reference.reference.startsWith(`${rt}/`)) {
+      return true;
+    }
+  }
+  return false;
 }

--- a/packages/subscriptions/src/r4b/__fhir-subscription.ts
+++ b/packages/subscriptions/src/r4b/__fhir-subscription.ts
@@ -1,6 +1,7 @@
 import {
   AnyResource,
   FhirClient,
+  Retrieved,
   Subscription,
   build,
   urlSafeConcat,
@@ -32,7 +33,7 @@ export interface FhirSubscriptionHandlerArgs<
   fhirClient: FhirClient;
 
   /** The resource that matches the subscription. */
-  resource: TResource;
+  resource: Retrieved<TResource>;
 
   /** The configured logger. */
   logger:

--- a/packages/subscriptions/src/r5/__fhir-subscription.ts
+++ b/packages/subscriptions/src/r5/__fhir-subscription.ts
@@ -1,6 +1,7 @@
 import {
   AnyResource,
   FhirClient,
+  Retrieved,
   Subscription,
   SubscriptionFilterBy,
 } from "@bonfhir/core/r5";
@@ -31,7 +32,7 @@ export interface FhirSubscriptionHandlerArgs<
   fhirClient: FhirClient;
 
   /** The resource that matches the subscription. */
-  resource: TResource;
+  resource: Retrieved<TResource>;
 
   /** The configured logger. */
   logger:


### PR DESCRIPTION
This PR contains small QOL improvements:
 - add `isReferenceOf` helper
 - updated type for subscription args to `Retrieved<Resource>`