### PR TITLE
create-bonfhir package

### DIFF
--- a/.changeset/metal-kangaroos-beg.md
+++ b/.changeset/metal-kangaroos-beg.md
@@ -1,0 +1,5 @@
+---
+"@bonfhir/cli": patch
+---
+
+Create exports for commands (use it as a package)

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -28,10 +28,22 @@
   },
   "type": "module",
   "bin": {
-    "bonfhir": "./dist/cjs/index.cjs"
+    "bonfhir": "./dist/cli/index.cjs"
+  },
+  "exports": {
+    ".": {
+      "import": {
+        "types": "./dist/esm/index.d.ts",
+        "default": "./dist/esm/index.mjs"
+      },
+      "required": {
+        "types": "./dist/cjs/index.d.ts",
+        "default": "./dist/cjs/index.cjs"
+      }
+    }
   },
   "devDependencies": {
-    "@bonfhir/core": "^2.10.0",
+    "@bonfhir/core": "workspace:*",
     "@bonfhir/eslint-config": "workspace:*",
     "@bonfhir/eslint-plugin": "workspace:*",
     "@bonfhir/prettier-config": "workspace:*",
@@ -57,6 +69,7 @@
     "listr2": "^6.6.1",
     "rimraf": "^5.0.1",
     "rollup": "^3.27.0",
+    "rollup-plugin-dts": "5.3.1",
     "rollup-plugin-filesize": "^10.0.0",
     "ts-node": "^10.9.1",
     "typescript": "^5.1.6",

--- a/packages/cli/src/cli.ts
+++ b/packages/cli/src/cli.ts
@@ -1,0 +1,21 @@
+import chalk from "chalk";
+import yargs from "yargs";
+import { _import, create } from "./commands";
+
+try {
+  yargs()
+    .scriptName("bonfhir")
+    .demand(1, chalk.red("Error: Must provide a valid command"))
+    .help("h")
+    .alias("h", "help")
+    .strictCommands()
+    .command(_import)
+    .command(create)
+    .demandCommand(1)
+    .version(process.env.PACKAGE_VERSION || "local")
+    .parse(process.argv.slice(2));
+} catch (error) {
+  console.error(chalk.red(error));
+  console.error();
+  console.error(chalk.gray((error as Error).stack));
+}

--- a/packages/cli/src/commands/index.ts
+++ b/packages/cli/src/commands/index.ts
@@ -1,0 +1,2 @@
+export { default as create } from "./create";
+export { default as _import } from "./import";

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -1,22 +1,3 @@
-import chalk from "chalk";
-import yargs from "yargs";
-import create from "./commands/create";
-import _import from "./commands/import";
-
-try {
-  yargs()
-    .scriptName("bonfhir")
-    .demand(1, chalk.red("Error: Must provide a valid command"))
-    .help("h")
-    .alias("h", "help")
-    .strictCommands()
-    .command(_import)
-    .command(create)
-    .demandCommand(1)
-    .version(process.env.PACKAGE_VERSION || "local")
-    .parse(process.argv.slice(2));
-} catch (error) {
-  console.error(chalk.red(error));
-  console.error();
-  console.error(chalk.gray((error as Error).stack));
-}
+export * from "./commands";
+export * from "./modules";
+export * from "./templates";

--- a/packages/cli/src/templates/index.ts
+++ b/packages/cli/src/templates/index.ts
@@ -4,4 +4,4 @@ import { Next } from "./next";
 import { Template } from "./template";
 import { Vite } from "./vite";
 
-export const Templates: Template[] = [Vite, Next, Lambda, Monorepo];
+export const Templates: Template[] = [Vite, Lambda, Next, Monorepo];

--- a/packages/create-bonfhir/.eslintrc.cjs
+++ b/packages/create-bonfhir/.eslintrc.cjs
@@ -1,0 +1,9 @@
+/**
+ * @type {import("eslint").Linter.Config}
+ */
+module.exports = {
+  extends: "@bonfhir/eslint-config",
+  env: {
+    node: true,
+  },
+};

--- a/packages/create-bonfhir/.npmignore
+++ b/packages/create-bonfhir/.npmignore
@@ -1,0 +1,8 @@
+.turbo/
+fixtures/
+src/
+.eslintrc.cjs
+jest.config.mjs
+rollup.config.mjs
+tsconfig.build.json
+tsconfig.json

--- a/packages/create-bonfhir/jest.config.mjs
+++ b/packages/create-bonfhir/jest.config.mjs
@@ -1,0 +1,6 @@
+/** @type {import('jest').Config} */
+export default {
+  transform: {
+    "^.+\\.tsx?$": ["esbuild-jest", { sourcemap: true }],
+  },
+};

--- a/packages/create-bonfhir/package.json
+++ b/packages/create-bonfhir/package.json
@@ -1,0 +1,67 @@
+{
+  "name": "create-bonfhir",
+  "version": "2.2.0",
+  "description": "Create a new BonFHIR project",
+  "keywords": [
+    "HL7",
+    "FHIR",
+    "BonFHIR",
+    "CLI"
+  ],
+  "homepage": "https://bonfhir.dev/",
+  "bugs": {
+    "url": "https://github.com/bonfhir/bonfhir/issues"
+  },
+  "license": "Apache-2.0",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/bonfhir/bonfhir.git",
+    "directory": "packages/cli"
+  },
+  "scripts": {
+    "build": "pnpm clean && rollup --config rollup.config.mjs",
+    "check": "prettier --check ./src && eslint ./src && tsc --noEmit",
+    "clean": "rimraf dist",
+    "dev": "ts-node src/index.ts",
+    "format": "eslint --fix ./src && prettier --log-level warn --write ./src",
+    "test": "jest"
+  },
+  "type": "module",
+  "bin": {
+    "create-bonfhir": "./dist/cjs/index.cjs"
+  },
+  "devDependencies": {
+    "@bonfhir/cli": "workspace:*",
+    "@bonfhir/core": "workspace:*",
+    "@bonfhir/eslint-config": "workspace:*",
+    "@bonfhir/eslint-plugin": "workspace:*",
+    "@bonfhir/prettier-config": "workspace:*",
+    "@bonfhir/typescript-config": "workspace:*",
+    "@rollup/plugin-commonjs": "^25.0.3",
+    "@rollup/plugin-json": "^6.0.0",
+    "@rollup/plugin-node-resolve": "^15.1.0",
+    "@rollup/plugin-replace": "^5.0.2",
+    "@rollup/plugin-terser": "^0.4.3",
+    "@rollup/plugin-typescript": "^11.1.2",
+    "@swc/core": "^1.3.72",
+    "@types/decompress": "^4.2.4",
+    "@types/inquirer": "^9.0.3",
+    "@types/jest": "^29.5.3",
+    "@types/node": "^18.17.1",
+    "@types/yargs": "^17.0.24",
+    "chalk": "^5.3.0",
+    "decompress": "^4.2.1",
+    "esbuild-jest": "^0.5.0",
+    "fast-glob": "^3.3.1",
+    "inquirer": "^8.2.6",
+    "jest": "^29.6.2",
+    "listr2": "^6.6.1",
+    "rimraf": "^5.0.1",
+    "rollup": "^3.27.0",
+    "rollup-plugin-filesize": "^10.0.0",
+    "ts-node": "^10.9.1",
+    "typescript": "^5.1.6",
+    "yargs": "^17.7.2"
+  },
+  "prettier": "@bonfhir/prettier-config"
+}

--- a/packages/create-bonfhir/rollup.config.mjs
+++ b/packages/create-bonfhir/rollup.config.mjs
@@ -1,0 +1,65 @@
+import commonjs from "@rollup/plugin-commonjs";
+import json from "@rollup/plugin-json";
+import { nodeResolve } from "@rollup/plugin-node-resolve";
+import replace from "@rollup/plugin-replace";
+import terser from "@rollup/plugin-terser";
+import typescript from "@rollup/plugin-typescript";
+import { mkdirSync, readFileSync, writeFileSync } from "node:fs";
+import filesize from "rollup-plugin-filesize";
+
+export default [
+  {
+    input: "src/index.ts",
+    output: [
+      {
+        file: "dist/cjs/index.cjs",
+        format: "cjs",
+        sourcemap: true,
+        compact: true,
+        banner: "#!/usr/bin/env node",
+        inlineDynamicImports: true,
+      },
+    ],
+    plugins: [
+      replace({
+        preventAssignment: true,
+        values: {
+          "process.env.PACKAGE_VERSION": `"${
+            JSON.parse(readFileSync("package.json", "utf8")).version
+          }"`,
+        },
+      }),
+      nodeResolve({
+        exportConditions: ["node"],
+        preferBuiltins: true,
+      }),
+      commonjs(),
+      json(),
+      typescript({
+        outDir: `dist/cjs`,
+        declarationMap: false,
+        declaration: false,
+        exclude: ["**/*.test.ts"],
+      }),
+      terser({
+        compress: false,
+        mangle: false,
+        output: {
+          comments: false,
+        },
+      }),
+      {
+        buildEnd: () => {
+          mkdirSync(`./dist/cjs`, { recursive: true });
+          writeFileSync(`./dist/cjs/package.json`, `{"type": "cjs"}`);
+        },
+      },
+      filesize(),
+    ],
+    onwarn(warning, warn) {
+      if (["THIS_IS_UNDEFINED", "CIRCULAR_DEPENDENCY"].includes(warning.code))
+        return;
+      warn(warning);
+    },
+  },
+];

--- a/packages/create-bonfhir/src/index.ts
+++ b/packages/create-bonfhir/src/index.ts
@@ -1,0 +1,9 @@
+import { create } from "@bonfhir/cli";
+import yargs from "yargs";
+
+// This package is essentially a wrapper around the @bonfhir/cli create command to support a more natural CLI experience
+yargs()
+  .command(create)
+  .demandCommand(1)
+  .version(process.env.PACKAGE_VERSION || "local")
+  .parse(["create", ...process.argv.slice(2)]);

--- a/packages/create-bonfhir/tsconfig.json
+++ b/packages/create-bonfhir/tsconfig.json
@@ -1,0 +1,13 @@
+{
+  "extends": "@bonfhir/typescript-config/tsconfig.json",
+  "include": ["src/**/*"],
+  "compilerOptions": {
+    "allowSyntheticDefaultImports": true
+  },
+  "ts-node": {
+    "esm": true,
+    "swc": true,
+    "transpileOnly": true,
+    "experimentalSpecifierResolution": "node"
+  }
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -490,7 +490,7 @@ importers:
   packages/cli:
     devDependencies:
       '@bonfhir/core':
-        specifier: ^2.10.0
+        specifier: workspace:*
         version: link:../core
       '@bonfhir/eslint-config':
         specifier: workspace:*
@@ -567,6 +567,9 @@ importers:
       rollup:
         specifier: ^3.27.0
         version: 3.27.0
+      rollup-plugin-dts:
+        specifier: 5.3.1
+        version: 5.3.1(rollup@3.27.0)(typescript@5.1.6)
       rollup-plugin-filesize:
         specifier: ^10.0.0
         version: 10.0.0
@@ -762,6 +765,102 @@ importers:
       typescript:
         specifier: ^5.1.6
         version: 5.1.6
+
+  packages/create-bonfhir:
+    devDependencies:
+      '@bonfhir/cli':
+        specifier: workspace:*
+        version: link:../cli
+      '@bonfhir/core':
+        specifier: workspace:*
+        version: link:../core
+      '@bonfhir/eslint-config':
+        specifier: workspace:*
+        version: link:../eslint-config
+      '@bonfhir/eslint-plugin':
+        specifier: workspace:*
+        version: link:../eslint-plugin
+      '@bonfhir/prettier-config':
+        specifier: workspace:*
+        version: link:../prettier-config
+      '@bonfhir/typescript-config':
+        specifier: workspace:*
+        version: link:../typescript-config
+      '@rollup/plugin-commonjs':
+        specifier: ^25.0.3
+        version: 25.0.3(rollup@3.27.0)
+      '@rollup/plugin-json':
+        specifier: ^6.0.0
+        version: 6.0.0(rollup@3.27.0)
+      '@rollup/plugin-node-resolve':
+        specifier: ^15.1.0
+        version: 15.1.0(rollup@3.27.0)
+      '@rollup/plugin-replace':
+        specifier: ^5.0.2
+        version: 5.0.2(rollup@3.27.0)
+      '@rollup/plugin-terser':
+        specifier: ^0.4.3
+        version: 0.4.3(rollup@3.27.0)
+      '@rollup/plugin-typescript':
+        specifier: ^11.1.2
+        version: 11.1.2(rollup@3.27.0)(typescript@5.1.6)
+      '@swc/core':
+        specifier: ^1.3.72
+        version: 1.3.72
+      '@types/decompress':
+        specifier: ^4.2.4
+        version: 4.2.4
+      '@types/inquirer':
+        specifier: ^9.0.3
+        version: 9.0.3
+      '@types/jest':
+        specifier: ^29.5.3
+        version: 29.5.3
+      '@types/node':
+        specifier: ^18.17.1
+        version: 18.17.1
+      '@types/yargs':
+        specifier: ^17.0.24
+        version: 17.0.24
+      chalk:
+        specifier: ^5.3.0
+        version: 5.3.0
+      decompress:
+        specifier: ^4.2.1
+        version: 4.2.1
+      esbuild-jest:
+        specifier: ^0.5.0
+        version: 0.5.0(esbuild@0.18.17)
+      fast-glob:
+        specifier: ^3.3.1
+        version: 3.3.1
+      inquirer:
+        specifier: ^8.2.6
+        version: 8.2.6
+      jest:
+        specifier: ^29.6.2
+        version: 29.6.2(@types/node@18.17.1)(ts-node@10.9.1)
+      listr2:
+        specifier: ^6.6.1
+        version: 6.6.1
+      rimraf:
+        specifier: ^5.0.1
+        version: 5.0.1
+      rollup:
+        specifier: ^3.27.0
+        version: 3.27.0
+      rollup-plugin-filesize:
+        specifier: ^10.0.0
+        version: 10.0.0
+      ts-node:
+        specifier: ^10.9.1
+        version: 10.9.1(@swc/core@1.3.72)(@types/node@18.17.1)(typescript@5.1.6)
+      typescript:
+        specifier: ^5.1.6
+        version: 5.1.6
+      yargs:
+        specifier: ^17.7.2
+        version: 17.7.2
 
   packages/eslint-config:
     dependencies:
@@ -4942,7 +5041,6 @@ packages:
     cpu: [arm64]
     os: [android]
     requiresBuild: true
-    dev: true
     optional: true
 
   /@esbuild/android-arm@0.18.17:
@@ -4951,7 +5049,6 @@ packages:
     cpu: [arm]
     os: [android]
     requiresBuild: true
-    dev: true
     optional: true
 
   /@esbuild/android-x64@0.18.17:
@@ -4960,7 +5057,6 @@ packages:
     cpu: [x64]
     os: [android]
     requiresBuild: true
-    dev: true
     optional: true
 
   /@esbuild/darwin-arm64@0.18.17:
@@ -4969,7 +5065,6 @@ packages:
     cpu: [arm64]
     os: [darwin]
     requiresBuild: true
-    dev: true
     optional: true
 
   /@esbuild/darwin-x64@0.18.17:
@@ -4978,7 +5073,6 @@ packages:
     cpu: [x64]
     os: [darwin]
     requiresBuild: true
-    dev: true
     optional: true
 
   /@esbuild/freebsd-arm64@0.18.17:
@@ -4987,7 +5081,6 @@ packages:
     cpu: [arm64]
     os: [freebsd]
     requiresBuild: true
-    dev: true
     optional: true
 
   /@esbuild/freebsd-x64@0.18.17:
@@ -4996,7 +5089,6 @@ packages:
     cpu: [x64]
     os: [freebsd]
     requiresBuild: true
-    dev: true
     optional: true
 
   /@esbuild/linux-arm64@0.18.17:
@@ -5005,7 +5097,6 @@ packages:
     cpu: [arm64]
     os: [linux]
     requiresBuild: true
-    dev: true
     optional: true
 
   /@esbuild/linux-arm@0.18.17:
@@ -5014,7 +5105,6 @@ packages:
     cpu: [arm]
     os: [linux]
     requiresBuild: true
-    dev: true
     optional: true
 
   /@esbuild/linux-ia32@0.18.17:
@@ -5023,7 +5113,6 @@ packages:
     cpu: [ia32]
     os: [linux]
     requiresBuild: true
-    dev: true
     optional: true
 
   /@esbuild/linux-loong64@0.18.17:
@@ -5032,7 +5121,6 @@ packages:
     cpu: [loong64]
     os: [linux]
     requiresBuild: true
-    dev: true
     optional: true
 
   /@esbuild/linux-mips64el@0.18.17:
@@ -5041,7 +5129,6 @@ packages:
     cpu: [mips64el]
     os: [linux]
     requiresBuild: true
-    dev: true
     optional: true
 
   /@esbuild/linux-ppc64@0.18.17:
@@ -5050,7 +5137,6 @@ packages:
     cpu: [ppc64]
     os: [linux]
     requiresBuild: true
-    dev: true
     optional: true
 
   /@esbuild/linux-riscv64@0.18.17:
@@ -5059,7 +5145,6 @@ packages:
     cpu: [riscv64]
     os: [linux]
     requiresBuild: true
-    dev: true
     optional: true
 
   /@esbuild/linux-s390x@0.18.17:
@@ -5068,7 +5153,6 @@ packages:
     cpu: [s390x]
     os: [linux]
     requiresBuild: true
-    dev: true
     optional: true
 
   /@esbuild/linux-x64@0.18.17:
@@ -5077,7 +5161,6 @@ packages:
     cpu: [x64]
     os: [linux]
     requiresBuild: true
-    dev: true
     optional: true
 
   /@esbuild/netbsd-x64@0.18.17:
@@ -5086,7 +5169,6 @@ packages:
     cpu: [x64]
     os: [netbsd]
     requiresBuild: true
-    dev: true
     optional: true
 
   /@esbuild/openbsd-x64@0.18.17:
@@ -5095,7 +5177,6 @@ packages:
     cpu: [x64]
     os: [openbsd]
     requiresBuild: true
-    dev: true
     optional: true
 
   /@esbuild/sunos-x64@0.18.17:
@@ -5104,7 +5185,6 @@ packages:
     cpu: [x64]
     os: [sunos]
     requiresBuild: true
-    dev: true
     optional: true
 
   /@esbuild/win32-arm64@0.18.17:
@@ -5113,7 +5193,6 @@ packages:
     cpu: [arm64]
     os: [win32]
     requiresBuild: true
-    dev: true
     optional: true
 
   /@esbuild/win32-ia32@0.18.17:
@@ -5122,7 +5201,6 @@ packages:
     cpu: [ia32]
     os: [win32]
     requiresBuild: true
-    dev: true
     optional: true
 
   /@esbuild/win32-x64@0.18.17:
@@ -5131,7 +5209,6 @@ packages:
     cpu: [x64]
     os: [win32]
     requiresBuild: true
-    dev: true
     optional: true
 
   /@eslint-community/eslint-utils@4.4.0(eslint@8.46.0):
@@ -8273,7 +8350,7 @@ packages:
       filenamify: 4.3.0
       get-stream: 6.0.1
       got: 11.8.6
-      inquirer: 8.2.5
+      inquirer: 8.2.6
       js-yaml: 4.1.0
       jwt-decode: 3.1.2
       lodash: 4.17.21
@@ -10132,7 +10209,6 @@ packages:
     cpu: [arm64]
     os: [darwin]
     requiresBuild: true
-    dev: true
     optional: true
 
   /@swc/core-darwin-x64@1.3.72:
@@ -10141,7 +10217,6 @@ packages:
     cpu: [x64]
     os: [darwin]
     requiresBuild: true
-    dev: true
     optional: true
 
   /@swc/core-linux-arm-gnueabihf@1.3.72:
@@ -10150,7 +10225,6 @@ packages:
     cpu: [arm]
     os: [linux]
     requiresBuild: true
-    dev: true
     optional: true
 
   /@swc/core-linux-arm64-gnu@1.3.72:
@@ -10159,7 +10233,6 @@ packages:
     cpu: [arm64]
     os: [linux]
     requiresBuild: true
-    dev: true
     optional: true
 
   /@swc/core-linux-arm64-musl@1.3.72:
@@ -10168,7 +10241,6 @@ packages:
     cpu: [arm64]
     os: [linux]
     requiresBuild: true
-    dev: true
     optional: true
 
   /@swc/core-linux-x64-gnu@1.3.72:
@@ -10177,7 +10249,6 @@ packages:
     cpu: [x64]
     os: [linux]
     requiresBuild: true
-    dev: true
     optional: true
 
   /@swc/core-linux-x64-musl@1.3.72:
@@ -10186,7 +10257,6 @@ packages:
     cpu: [x64]
     os: [linux]
     requiresBuild: true
-    dev: true
     optional: true
 
   /@swc/core-win32-arm64-msvc@1.3.72:
@@ -10195,7 +10265,6 @@ packages:
     cpu: [arm64]
     os: [win32]
     requiresBuild: true
-    dev: true
     optional: true
 
   /@swc/core-win32-ia32-msvc@1.3.72:
@@ -10204,7 +10273,6 @@ packages:
     cpu: [ia32]
     os: [win32]
     requiresBuild: true
-    dev: true
     optional: true
 
   /@swc/core-win32-x64-msvc@1.3.72:
@@ -10213,7 +10281,6 @@ packages:
     cpu: [x64]
     os: [win32]
     requiresBuild: true
-    dev: true
     optional: true
 
   /@swc/core@1.3.72:
@@ -10236,7 +10303,6 @@ packages:
       '@swc/core-win32-arm64-msvc': 1.3.72
       '@swc/core-win32-ia32-msvc': 1.3.72
       '@swc/core-win32-x64-msvc': 1.3.72
-    dev: true
 
   /@swc/helpers@0.5.1:
     resolution: {integrity: sha512-sJ902EfIzn1Fa+qYmjdQqh8tPsoxyBz+8yBKC2HKUxyezKJFwPGOn7pv4WY6QuQW//ySQi5lJjA/ZT9sNWWNTg==}
@@ -12345,7 +12411,7 @@ packages:
       loader-utils: 2.0.4
       make-dir: 3.1.0
       schema-utils: 2.7.1
-      webpack: 5.88.2
+      webpack: 5.88.2(@swc/core@1.3.72)(esbuild@0.18.17)
 
   /babel-loader@9.1.3(@babel/core@7.22.9)(webpack@5.88.2):
     resolution: {integrity: sha512-xG3ST4DglodGf8qSwv0MdeWLhrDsw/32QMdTO5T1ZIp9gQur0HkCyFs7Awskr10JKXFXwpAhiCuYX5oGXnRGbw==}
@@ -13886,7 +13952,7 @@ packages:
       postcss-modules-values: 4.0.0(postcss@8.4.25)
       postcss-value-parser: 4.2.0
       semver: 7.5.4
-      webpack: 5.88.2
+      webpack: 5.88.2(@swc/core@1.3.72)(esbuild@0.18.17)
 
   /css-minimizer-webpack-plugin@3.4.1(esbuild@0.18.17)(webpack@5.88.2):
     resolution: {integrity: sha512-1u6D71zeIfgngN2XNRJefc/hY7Ybsxd74Jm4qngIXyUEk7fss3VUzuHxLAq/R8NAba4QU9OUSaMZlbpRc7bM4Q==}
@@ -15086,7 +15152,6 @@ packages:
       '@esbuild/win32-arm64': 0.18.17
       '@esbuild/win32-ia32': 0.18.17
       '@esbuild/win32-x64': 0.18.17
-    dev: true
 
   /escalade@3.1.1:
     resolution: {integrity: sha512-k0er2gUkLf8O0zKJiAhmkTnJlTvINGv7ygDNPbeIsX/TJjGJZHuh9B2UxbsaEkmlEo9MfhrSzmhIlhRlI2GXnw==}
@@ -15208,7 +15273,7 @@ packages:
     dependencies:
       debug: 3.2.7(supports-color@5.5.0)
       is-core-module: 2.12.1
-      resolve: 1.22.2
+      resolve: 1.22.3
     transitivePeerDependencies:
       - supports-color
 
@@ -16039,7 +16104,7 @@ packages:
     dependencies:
       loader-utils: 2.0.4
       schema-utils: 3.3.0
-      webpack: 5.88.2
+      webpack: 5.88.2(@swc/core@1.3.72)(esbuild@0.18.17)
 
   /file-system-cache@2.3.0:
     resolution: {integrity: sha512-l4DMNdsIPsVnKrgEXbJwDJsA5mB8rGwHYERMgqQx/xAUtChPJMre1bXBzDEqqVbWv9AIbFezXMxeEkZDSrXUOQ==}
@@ -17180,7 +17245,7 @@ packages:
       lodash: 4.17.21
       pretty-error: 4.0.0
       tapable: 2.2.1
-      webpack: 5.88.2
+      webpack: 5.88.2(@swc/core@1.3.72)(esbuild@0.18.17)
 
   /htmlparser2@6.1.0:
     resolution: {integrity: sha512-gyyPk6rgonLFEDGoeRgQNaEUvdJ4ktTmmUh/h2t7s+M8oPpIPxgNACWa+6ESR57kXstwqPiCut0V8NRpcwgU7A==}
@@ -20232,7 +20297,7 @@ packages:
       webpack: ^5.0.0
     dependencies:
       schema-utils: 4.2.0
-      webpack: 5.88.2
+      webpack: 5.88.2(@swc/core@1.3.72)(esbuild@0.18.17)
 
   /minimalistic-assert@1.0.1:
     resolution: {integrity: sha512-UtJcAD4yEaGtjPezWuO9wC4nwUnVH/8/Im3yEHQP4b67cXlD/Qr9hdITCU1xDbSEXg2XKNaP8jsReV7vQd00/A==}
@@ -23868,6 +23933,7 @@ packages:
       is-core-module: 2.12.1
       path-parse: 1.0.7
       supports-preserve-symlinks-flag: 1.0.0
+    dev: true
 
   /resolve@1.22.3:
     resolution: {integrity: sha512-P8ur/gp/AmbEzjr729bZnLjXK5Z+4P0zhIJgBgzqRih7hL7BOukHGtSTA3ACMY467GRFz3duQsi0bDZdR7DKdw==}
@@ -25495,7 +25561,6 @@ packages:
       serialize-javascript: 6.0.1
       terser: 5.19.1
       webpack: 5.88.2(@swc/core@1.3.72)(esbuild@0.18.17)
-    dev: true
 
   /terser-webpack-plugin@5.3.9(webpack@5.88.2):
     resolution: {integrity: sha512-ZuXsqE07EcggTWQjXUj+Aot/OMcD0bMKGgF63f7UxYcu5/AJF53aIpK1YoP5xR9l6s/Hy2b+t1AM0bLNPRuhwA==}
@@ -26786,7 +26851,7 @@ packages:
       mime-types: 2.1.35
       range-parser: 1.2.1
       schema-utils: 4.2.0
-      webpack: 5.88.2
+      webpack: 5.88.2(@swc/core@1.3.72)(esbuild@0.18.17)
 
   /webpack-dev-middleware@6.1.1(webpack@5.88.2):
     resolution: {integrity: sha512-y51HrHaFeeWir0YO4f0g+9GwZawuigzcAdRNon6jErXy/SqV/+O6eaVAzDqE6t3e3NpGeR5CS+cCDaTC+V3yEQ==}
@@ -26846,7 +26911,7 @@ packages:
       serve-index: 1.9.1
       sockjs: 0.3.24
       spdy: 4.0.2
-      webpack: 5.88.2
+      webpack: 5.88.2(@swc/core@1.3.72)(esbuild@0.18.17)
       webpack-dev-middleware: 5.3.3(webpack@5.88.2)
       ws: 8.13.0
     transitivePeerDependencies:
@@ -26981,7 +27046,6 @@ packages:
       - '@swc/core'
       - esbuild
       - uglify-js
-    dev: true
 
   /webpackbar@5.0.2(webpack@5.88.2):
     resolution: {integrity: sha512-BmFJo7veBDgQzfWXl/wwYXr/VFus0614qZ8i9znqcl9fnEdiVkdbi0TedLQ6xAK92HZHDJ0QmyQ0fmuZPAgCYQ==}


### PR DESCRIPTION
This PR adds a new `create-bonfhir` package to support the npm `create` command naturally.
This is simply an alias for `@bonfhir/cli create`, but it should support the following command:

`npx create bonfhir`, which looks cool.