### PR TITLE
Add support for global browser import

### DIFF
--- a/.changeset/lazy-tigers-yawn.md
+++ b/.changeset/lazy-tigers-yawn.md
@@ -1,0 +1,5 @@
+---
+"@bonfhir/core": minor
+---
+
+Add support for global browser import

--- a/packages/core/.npmignore
+++ b/packages/core/.npmignore
@@ -6,4 +6,6 @@ templates/
 jest.config.mjs
 jest.setup.mjs
 rollup.config.mjs
+rollup-global.config.mjs
 tsconfig.json
+index.html

--- a/packages/core/index.html
+++ b/packages/core/index.html
@@ -1,0 +1,16 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <script type="text/javascript" src="dist/r4b/global/index.js"></script>
+    <script type="text/javascript">
+      console.log(bonfhir.build("Patient", {}));
+    </script>
+  </head>
+  <body>
+    <main>
+      <h1>Test browser import</h1>
+      <p>This file solely exists to be able to test the browser import build (global.ts).</p>
+      <p>Just run "npx -y http-server ." after a build and open in a browser, then open the console.</p>
+    </main>
+  </body>
+</html>

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -18,7 +18,7 @@
     "directory": "packages/core"
   },
   "scripts": {
-    "build": "pnpm clean && pnpm codegen && pnpm copyfiles && rollup --config rollup.config.mjs",
+    "build": "pnpm clean && pnpm codegen && pnpm copyfiles && rollup --config rollup.config.mjs && rollup --config rollup-global.config.mjs",
     "check": "prettier --check ./src && eslint ./src && tsc --noEmit",
     "clean": "rimraf dist && rimraf src/r4b/[!__]**",
     "copyfiles": "pnpm --dir=\"${PWD}/../codegen\" dev copy -s \"${PWD}/src/r5\" -t \"${PWD}/src/r4b\" -i '**/*.ts' -e '**/*.codegen.ts' --source-fhir r5 --target-fhir r4b",
@@ -37,7 +37,8 @@
       "require": {
         "types": "./dist/r4b/cjs/index.d.ts",
         "default": "./dist/r4b/cjs/index.cjs"
-      }
+      },
+      "script": "./dist/r4b/global/index.js"
     },
     "./r5": {
       "import": {
@@ -47,7 +48,8 @@
       "require": {
         "types": "./dist/r5/cjs/index.d.ts",
         "default": "./dist/r5/cjs/index.cjs"
-      }
+      },
+      "script": "./dist/r5/global/index.js"
     }
   },
   "devDependencies": {

--- a/packages/core/rollup-global.config.mjs
+++ b/packages/core/rollup-global.config.mjs
@@ -1,0 +1,52 @@
+import commonjs from "@rollup/plugin-commonjs";
+import { nodeResolve } from "@rollup/plugin-node-resolve";
+import replace from "@rollup/plugin-replace";
+import terser from "@rollup/plugin-terser";
+import typescript from "@rollup/plugin-typescript";
+import { readFileSync } from "node:fs";
+import filesize from "rollup-plugin-filesize";
+
+// This is a separate file as if included in the main rollup, nodejs explodes when compiling.
+export default ["r4b", "r5"].map((release) => ({
+  input: `src/${release}/global.ts`,
+  output: [
+    {
+      file: `dist/${release}/global/index.js`,
+      format: "cjs",
+      compact: true,
+    },
+  ],
+  plugins: [
+    replace({
+      preventAssignment: true,
+      values: {
+        "process.env.PACKAGE_VERSION": `"${
+          JSON.parse(readFileSync("package.json", "utf8")).version
+        }"`,
+      },
+    }),
+    nodeResolve({
+      exportConditions: ["node"],
+    }),
+    commonjs(),
+    typescript({
+      outDir: `dist/${release}`,
+      declaration: false,
+      declarationMap: false,
+      exclude: ["**/*.test.ts"],
+    }),
+    terser({
+      compress: false,
+      mangle: false,
+      output: {
+        comments: false,
+      },
+    }),
+    filesize(),
+  ],
+  onwarn(warning, warn) {
+    if (["THIS_IS_UNDEFINED", "CIRCULAR_DEPENDENCY"].includes(warning.code))
+      return;
+    warn(warning);
+  },
+}));

--- a/packages/core/src/r4b/global.ts
+++ b/packages/core/src/r4b/global.ts
@@ -1,0 +1,48 @@
+/**
+ * This module exists as an alternative entry-point to be able to directly reference the core library
+ * in a global import context, such as a browser.
+ * This enables usage in third-party tools such as no-code tools.
+ */
+
+import * as builders from "./builders";
+import * as bundleExecutor from "./bundle-executor";
+import * as bundleNavigator from "./bundle-navigator";
+import * as dateTimeHelpers from "./date-time-helpers";
+import * as dedupSearch from "./dedup-search";
+import * as extensions from "./extensions";
+import * as fetchFhirClient from "./fetch-fhir-client";
+import * as fhirClient from "./fhir-client";
+import * as fhirTypes from "./fhir-types.codegen";
+import * as formatters from "./formatters";
+import * as langUtils from "./lang-utils";
+import * as merge from "./merge";
+import * as narratives from "./narratives.codegen";
+import * as operations from "./operations.codegen";
+import * as patch from "./patch";
+import * as patchCodegen from "./patch.codegen";
+import * as references from "./references.codegen";
+import * as search from "./search";
+import * as searchCodegen from "./search.codegen";
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+(globalThis as any).bonfhir = {
+  ...builders,
+  ...bundleExecutor,
+  ...bundleNavigator,
+  ...dateTimeHelpers,
+  ...dedupSearch,
+  ...extensions,
+  ...fetchFhirClient,
+  ...fhirClient,
+  ...fhirTypes,
+  ...formatters,
+  ...langUtils,
+  ...merge,
+  ...narratives,
+  ...operations,
+  ...patchCodegen,
+  ...patch,
+  ...references,
+  ...searchCodegen,
+  ...search,
+};

--- a/packages/core/src/r5/global.ts
+++ b/packages/core/src/r5/global.ts
@@ -1,0 +1,48 @@
+/**
+ * This module exists as an alternative entry-point to be able to directly reference the core library
+ * in a global import context, such as a browser.
+ * This enables usage in third-party tools such as no-code tools.
+ */
+
+import * as builders from "./builders";
+import * as bundleExecutor from "./bundle-executor";
+import * as bundleNavigator from "./bundle-navigator";
+import * as dateTimeHelpers from "./date-time-helpers";
+import * as dedupSearch from "./dedup-search";
+import * as extensions from "./extensions";
+import * as fetchFhirClient from "./fetch-fhir-client";
+import * as fhirClient from "./fhir-client";
+import * as fhirTypes from "./fhir-types.codegen";
+import * as formatters from "./formatters";
+import * as langUtils from "./lang-utils";
+import * as merge from "./merge";
+import * as narratives from "./narratives.codegen";
+import * as operations from "./operations.codegen";
+import * as patch from "./patch";
+import * as patchCodegen from "./patch.codegen";
+import * as references from "./references.codegen";
+import * as search from "./search";
+import * as searchCodegen from "./search.codegen";
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+(globalThis as any).bonfhir = {
+  ...builders,
+  ...bundleExecutor,
+  ...bundleNavigator,
+  ...dateTimeHelpers,
+  ...dedupSearch,
+  ...extensions,
+  ...fetchFhirClient,
+  ...fhirClient,
+  ...fhirTypes,
+  ...formatters,
+  ...langUtils,
+  ...merge,
+  ...narratives,
+  ...operations,
+  ...patchCodegen,
+  ...patch,
+  ...references,
+  ...searchCodegen,
+  ...search,
+};


### PR DESCRIPTION
This should unlock the possibility to do this direclty in the browser once the packager is published:

```
<script type="text/javascript" src="https://www.jsdelivr.com/npm/@bonfhir/core@2.14.0/dist/r4b/global/index.js"></script>
```

Fix #34 