### PR TITLE
Fix #43: `FhirClient.capabilities` returns TerminologyCapabilities when mode=terminology

### DIFF
--- a/.changeset/red-cats-fly.md
+++ b/.changeset/red-cats-fly.md
@@ -1,0 +1,6 @@
+---
+"@bonfhir/core": patch
+"@bonfhir/query": patch
+---
+
+Fix #43: `FhirClient.capabilities` returns TerminologyCapabilities when mode=terminology

--- a/packages/core/src/r4b/fetch-fhir-client.ts
+++ b/packages/core/src/r4b/fetch-fhir-client.ts
@@ -40,6 +40,7 @@ import {
   OperationOutcome,
   Reference,
   Retrieved,
+  TerminologyCapabilities,
 } from "./fhir-types.codegen";
 import { urlSafeConcat } from "./lang-utils";
 import { Merger } from "./mergers/index";
@@ -578,11 +579,15 @@ export class FetchFhirClient implements FhirClient {
   /* eslint-enable @typescript-eslint/no-explicit-any */
 
   public async capabilities(
+    mode?: "full" | "normative" | null | undefined,
+  ): Promise<CapabilityStatement>;
+  public async capabilities(
+    mode: "terminology",
+  ): Promise<TerminologyCapabilities>;
+  public async capabilities(
     mode?: "full" | "normative" | "terminology" | null | undefined,
-  ): Promise<CapabilityStatement> {
-    return this.fetch<CapabilityStatement>(
-      `metadata${mode ? `?mode=${mode}` : ""}`,
-    );
+  ): Promise<CapabilityStatement | TerminologyCapabilities> {
+    return this.fetch(`metadata${mode ? `?mode=${mode}` : ""}`);
   }
 
   public batch(): BundleExecutor;

--- a/packages/core/src/r4b/fhir-client.ts
+++ b/packages/core/src/r4b/fhir-client.ts
@@ -17,6 +17,7 @@ import {
   OperationOutcome,
   Reference,
   Retrieved,
+  TerminologyCapabilities,
 } from "./fhir-types.codegen";
 import { Formatter } from "./formatters";
 import { merge } from "./merge";
@@ -239,8 +240,9 @@ export interface FhirClient {
    * https://hl7.org/fhir/http.html#capabilities
    */
   capabilities(
-    mode?: "full" | "normative" | "terminology" | null | undefined,
+    mode?: "full" | "normative" | null | undefined,
   ): Promise<CapabilityStatement>;
+  capabilities(mode: "terminology"): Promise<TerminologyCapabilities>;
 
   /**
    * The batch interaction submits a set of actions to perform on a server in a single HTTP request/response.

--- a/packages/core/src/r5/fetch-fhir-client.ts
+++ b/packages/core/src/r5/fetch-fhir-client.ts
@@ -40,6 +40,7 @@ import {
   OperationOutcome,
   Reference,
   Retrieved,
+  TerminologyCapabilities,
 } from "./fhir-types.codegen";
 import { urlSafeConcat } from "./lang-utils";
 import { Merger } from "./mergers/index";
@@ -578,11 +579,15 @@ export class FetchFhirClient implements FhirClient {
   /* eslint-enable @typescript-eslint/no-explicit-any */
 
   public async capabilities(
+    mode?: "full" | "normative" | null | undefined,
+  ): Promise<CapabilityStatement>;
+  public async capabilities(
+    mode: "terminology",
+  ): Promise<TerminologyCapabilities>;
+  public async capabilities(
     mode?: "full" | "normative" | "terminology" | null | undefined,
-  ): Promise<CapabilityStatement> {
-    return this.fetch<CapabilityStatement>(
-      `metadata${mode ? `?mode=${mode}` : ""}`,
-    );
+  ): Promise<CapabilityStatement | TerminologyCapabilities> {
+    return this.fetch(`metadata${mode ? `?mode=${mode}` : ""}`);
   }
 
   public batch(): BundleExecutor;

--- a/packages/core/src/r5/fhir-client.ts
+++ b/packages/core/src/r5/fhir-client.ts
@@ -17,6 +17,7 @@ import {
   OperationOutcome,
   Reference,
   Retrieved,
+  TerminologyCapabilities,
 } from "./fhir-types.codegen";
 import { Formatter } from "./formatters";
 import { merge } from "./merge";
@@ -239,8 +240,9 @@ export interface FhirClient {
    * https://hl7.org/fhir/http.html#capabilities
    */
   capabilities(
-    mode?: "full" | "normative" | "terminology" | null | undefined,
+    mode?: "full" | "normative" | null | undefined,
   ): Promise<CapabilityStatement>;
+  capabilities(mode: "terminology"): Promise<TerminologyCapabilities>;
 
   /**
    * The batch interaction submits a set of actions to perform on a server in a single HTTP request/response.

--- a/packages/query/src/r4b/hooks/use-fhir-capabilities.tsx
+++ b/packages/query/src/r4b/hooks/use-fhir-capabilities.tsx
@@ -1,8 +1,7 @@
+/* eslint-disable @typescript-eslint/no-explicit-any */
 import {
-  AnyResourceType,
   CapabilityStatement,
-  ExtractResource,
-  Retrieved,
+  TerminologyCapabilities,
 } from "@bonfhir/core/r4b";
 import {
   UseQueryOptions,
@@ -13,16 +12,16 @@ import { FhirQueryKeys } from "../cache-keys";
 import { useFhirClientQueryContext } from "../context";
 
 export interface UseFhirCapabilitiesOptions<
-  TResourceType extends AnyResourceType,
+  TResourceType extends CapabilityStatement | TerminologyCapabilities,
 > {
   /** The FhirClient key to use to perform the query. */
   fhirClient?: string | null | undefined;
   query?:
     | Omit<
         UseQueryOptions<
-          Retrieved<ExtractResource<TResourceType>>,
+          TResourceType,
           unknown,
-          Retrieved<ExtractResource<TResourceType>>,
+          TResourceType,
           ReturnType<(typeof FhirQueryKeys)["capabilities"]>
         >,
         "initialData" | "queryKey" | "queryFn"
@@ -32,20 +31,30 @@ export interface UseFhirCapabilitiesOptions<
 }
 
 /**
- * Return a [Query](https://tanstack.com/query/latest/docs/react/guides/queries) for a read request.
+ * The capabilities interaction retrieves the information about a server's capabilities - which portions of this specification it supports.
  *
- * @see https://hl7.org/fhir/http.html#read
+ * https://hl7.org/fhir/http.html#capabilities
  */
-export function useFhirCapabilities<TResourceType extends AnyResourceType>(
+export function useFhirCapabilities(
+  mode?: "full" | "normative" | null | undefined,
+  options?: UseFhirCapabilitiesOptions<CapabilityStatement> | null | undefined,
+): UseQueryResult<CapabilityStatement>;
+export function useFhirCapabilities(
+  mode: "terminology",
+  options?:
+    | UseFhirCapabilitiesOptions<TerminologyCapabilities>
+    | null
+    | undefined,
+): UseQueryResult<TerminologyCapabilities>;
+export function useFhirCapabilities(
   mode?: "full" | "normative" | "terminology" | null | undefined,
-  options?: UseFhirCapabilitiesOptions<TResourceType> | null | undefined,
-): UseQueryResult<CapabilityStatement> {
+  options?: UseFhirCapabilitiesOptions<any> | null | undefined,
+): UseQueryResult<CapabilityStatement | TerminologyCapabilities> {
   const fhirQueryContext = useFhirClientQueryContext(options?.fhirClient);
 
   return useQuery({
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
     ...(options?.query as any),
     queryKey: FhirQueryKeys.capabilities(fhirQueryContext.clientKey, mode),
-    queryFn: () => fhirQueryContext.fhirClient.capabilities(mode),
+    queryFn: () => fhirQueryContext.fhirClient.capabilities(mode as any),
   });
 }


### PR DESCRIPTION
Fix the `capabilities` type signature when `mode=terminology`.