### PR TITLE
42-support-questionnaireansweroptioninitialselected-in-fhirquestionnaire

### DIFF
--- a/.changeset/dull-points-doubt.md
+++ b/.changeset/dull-points-doubt.md
@@ -1,0 +1,5 @@
+---
+"@bonfhir/ui-mantine": patch
+---
+
+Fix #42: add support for `Questionnaire.answerOption.initialSelected`

--- a/docs/storybook/.storybook/mock-fhir-client.ts
+++ b/docs/storybook/.storybook/mock-fhir-client.ts
@@ -153,6 +153,34 @@ export const mockClient = {
                       answerValueSet:
                         "http://hl7.org/fhir/ValueSet/administrative-gender",
                     },
+                    {
+                      id: "id-7",
+                      linkId: "morning-eating-habit",
+                      type: "choice",
+                      text: "How often do you eat in the morning?",
+                      answerOption: [
+                        {
+                          valueCoding: {
+                            code: "every-day",
+                            display: "Every day",
+                          },
+                          initialSelected: true,
+                        },
+                        {
+                          valueCoding: {
+                            code: "once-a-week",
+                            display: "Once a week",
+                          },
+                        },
+                        {
+                          valueCoding: {
+                            code: "never",
+                            display: "Never",
+                          },
+                          valueString: "Never",
+                        },
+                      ],
+                    },
                   ],
                 },
               ],

--- a/docs/storybook/package.json
+++ b/docs/storybook/package.json
@@ -6,8 +6,8 @@
     "build": "storybook build -o dist",
     "check": "prettier --check ./src && eslint ./src && tsc --noEmit",
     "clean": "rimraf dist",
-    "format": "eslint --fix ./src && prettier --log-level warn --write ./src",
-    "watch": "storybook dev -p 6006"
+    "dev": "storybook dev -p 6006",
+    "format": "eslint --fix ./src && prettier --log-level warn --write ./src"
   },
   "type": "module",
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -7,13 +7,13 @@
     "docs/*"
   ],
   "scripts": {
+    "all": "pnpm build && pnpm check && pnpm test",
     "build": "turbo run build",
     "check": "turbo run check",
     "codegen": "turbo run codegen",
     "dev": "turbo run dev",
     "format": "turbo run format",
     "preinstall": "npx only-allow pnpm",
-    "prepush": "pnpm build && pnpm check && pnpm test",
     "version-packages": "changeset version && pnpm install --lockfile-only",
     "publish-packages": "turbo run build && changeset publish",
     "test": "turbo run test -- --passWithNoTests",

--- a/packages/ui-mantine/src/r4b/inputs/fhir-questionnaire.tsx
+++ b/packages/ui-mantine/src/r4b/inputs/fhir-questionnaire.tsx
@@ -349,7 +349,8 @@ function buildInitialValues(
         break;
       }
       default: {
-        const initialValue = responseI?.answer || i.initial;
+        const initialValue = responseI?.answer ||
+          i.initial || [i.answerOption?.find((ao) => ao.initialSelected)];
         result[i.linkId] = Object.entries(initialValue?.[0] || {}).find(
           ([key, value]) => key.startsWith("value") && value,
         )?.[1];
@@ -362,8 +363,18 @@ function buildInitialValues(
 function convertAnswerOptions(
   answerOption: QuestionnaireItemAnswerOption[],
 ): ValueSetExpansionContains[] {
-  return answerOption.map((option) => ({
-    code: option.valueCoding?.code,
-    display: option.valueCoding?.display,
-  }));
+  return answerOption
+    .map((option) => {
+      if (option.valueCoding) {
+        return {
+          code: option.valueCoding?.code,
+          display: option.valueCoding?.display,
+        };
+      }
+      console.warn(
+        `Unsupported answerOption value format: ${JSON.stringify(option)}`,
+      );
+      return;
+    })
+    .filter(Boolean) as ValueSetExpansionContains[];
 }

--- a/packages/ui-mantine/src/r5/inputs/fhir-questionnaire.tsx
+++ b/packages/ui-mantine/src/r5/inputs/fhir-questionnaire.tsx
@@ -349,7 +349,8 @@ function buildInitialValues(
         break;
       }
       default: {
-        const initialValue = responseI?.answer || i.initial;
+        const initialValue = responseI?.answer ||
+          i.initial || [i.answerOption?.find((ao) => ao.initialSelected)];
         result[i.linkId] = Object.entries(initialValue?.[0] || {}).find(
           ([key, value]) => key.startsWith("value") && value,
         )?.[1];
@@ -362,8 +363,18 @@ function buildInitialValues(
 function convertAnswerOptions(
   answerOption: QuestionnaireItemAnswerOption[],
 ): ValueSetExpansionContains[] {
-  return answerOption.map((option) => ({
-    code: option.valueCoding?.code,
-    display: option.valueCoding?.display,
-  }));
+  return answerOption
+    .map((option) => {
+      if (option.valueCoding) {
+        return {
+          code: option.valueCoding?.code,
+          display: option.valueCoding?.display,
+        };
+      }
+      console.warn(
+        `Unsupported answerOption value format: ${JSON.stringify(option)}`,
+      );
+      return;
+    })
+    .filter(Boolean) as ValueSetExpansionContains[];
 }


### PR DESCRIPTION
Fix #42 - support for `FhirQuestionnaire.answerOption.initialSelected`.