### PR TITLE
Fix #4 - Missing label on terminology input when using segmented control

### DIFF
--- a/.changeset/lovely-planets-jog.md
+++ b/.changeset/lovely-planets-jog.md
@@ -1,0 +1,5 @@
+---
+"@bonfhir/ui-mantine": patch
+---
+
+Fix #4 - Missing label on terminology input when using segmented control

--- a/apps/sample-ehr/src/pages/questionnaires/[url].tsx
+++ b/apps/sample-ehr/src/pages/questionnaires/[url].tsx
@@ -1,7 +1,7 @@
 import { MainPage } from "@/components";
 import { QuestionnaireResponse } from "@bonfhir/core/r4b";
 import { FhirQuestionnaire } from "@bonfhir/ui/r4b";
-import { Stack } from "@mantine/core";
+import { Paper, Stack } from "@mantine/core";
 import { Prism } from "@mantine/prism";
 import { useRouter } from "next/router";
 import { useState } from "react";
@@ -15,17 +15,19 @@ export default function QuestionnairePage() {
 
   return (
     <MainPage>
-      <Stack>
-        <FhirQuestionnaire
-          source={url}
-          onSubmit={setQuestionnaireResponse}
-          onCancel={() => router.push("/")}
-          rendererProps={{ mainStack: { w: "50%" } }}
-        />
-        <Prism language="json">
-          {JSON.stringify(questionnaireResponse, undefined, 2) || ""}
-        </Prism>
-      </Stack>
+      <Paper>
+        <Stack>
+          <FhirQuestionnaire
+            source={url}
+            onSubmit={setQuestionnaireResponse}
+            onCancel={() => router.push("/")}
+            rendererProps={{ mainStack: { w: "50%" } }}
+          />
+          <Prism language="json">
+            {JSON.stringify(questionnaireResponse, undefined, 2) || ""}
+          </Prism>
+        </Stack>
+      </Paper>
     </MainPage>
   );
 }

--- a/packages/ui-mantine/src/r4b/inputs/input-types/fhir-input-terminology.tsx
+++ b/packages/ui-mantine/src/r4b/inputs/input-types/fhir-input-terminology.tsx
@@ -6,6 +6,8 @@ import {
 } from "@bonfhir/core/r4b";
 import { FhirInputTerminologyRendererProps } from "@bonfhir/ui/r4b";
 import {
+  Input,
+  InputWrapperProps,
   Loader,
   Radio,
   RadioGroupProps,
@@ -130,27 +132,27 @@ export function MantineFhirInputTerminology(
 
   if (props.mode === "segmented") {
     return (
-      <SegmentedControl
-        // eslint-disable-next-line @typescript-eslint/ban-ts-comment
-        // @ts-expect-error
+      <Input.Wrapper
         label={props.label}
         description={props.description}
         error={props.error}
-        placeholder={props.placeholder ?? undefined}
         required={Boolean(props.required)}
-        disabled={Boolean(props.disabled)}
-        fullWidth
-        value={value as any}
-        onChange={onChange}
-        data={
-          props.data.map((element) => ({
-            value: element.code,
+        {...(props.rendererProps as any)?.wrapper}
+      >
+        <SegmentedControl
+          disabled={Boolean(props.disabled)}
+          fullWidth
+          value={value as any}
+          onChange={onChange}
+          // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+          // @ts-expect-error
+          data={props.data.map((element) => ({
+            value: element.code || "",
             label: element.display,
-            item: element,
-          })) as any
-        }
-        {...props.rendererProps}
-      />
+          }))}
+          {...props.rendererProps}
+        />
+      </Input.Wrapper>
     );
   }
 
@@ -160,7 +162,7 @@ export function MantineFhirInputTerminology(
 export type MantineFhirInputTerminologyProps =
   | SelectProps
   | RadioGroupProps
-  | SegmentedControlProps;
+  | (SegmentedControlProps & { wrapper: InputWrapperProps });
 
 /**
  * Item types for terminology-related inputs.

--- a/packages/ui-mantine/src/r5/inputs/input-types/fhir-input-terminology.tsx
+++ b/packages/ui-mantine/src/r5/inputs/input-types/fhir-input-terminology.tsx
@@ -6,6 +6,8 @@ import {
 } from "@bonfhir/core/r5";
 import { FhirInputTerminologyRendererProps } from "@bonfhir/ui/r5";
 import {
+  Input,
+  InputWrapperProps,
   Loader,
   Radio,
   RadioGroupProps,
@@ -130,27 +132,27 @@ export function MantineFhirInputTerminology(
 
   if (props.mode === "segmented") {
     return (
-      <SegmentedControl
-        // eslint-disable-next-line @typescript-eslint/ban-ts-comment
-        // @ts-expect-error
+      <Input.Wrapper
         label={props.label}
         description={props.description}
         error={props.error}
-        placeholder={props.placeholder ?? undefined}
         required={Boolean(props.required)}
-        disabled={Boolean(props.disabled)}
-        fullWidth
-        value={value as any}
-        onChange={onChange}
-        data={
-          props.data.map((element) => ({
-            value: element.code,
+        {...(props.rendererProps as any)?.wrapper}
+      >
+        <SegmentedControl
+          disabled={Boolean(props.disabled)}
+          fullWidth
+          value={value as any}
+          onChange={onChange}
+          // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+          // @ts-expect-error
+          data={props.data.map((element) => ({
+            value: element.code || "",
             label: element.display,
-            item: element,
-          })) as any
-        }
-        {...props.rendererProps}
-      />
+          }))}
+          {...props.rendererProps}
+        />
+      </Input.Wrapper>
     );
   }
 
@@ -160,7 +162,7 @@ export function MantineFhirInputTerminology(
 export type MantineFhirInputTerminologyProps =
   | SelectProps
   | RadioGroupProps
-  | SegmentedControlProps;
+  | (SegmentedControlProps & { wrapper: InputWrapperProps });
 
 /**
  * Item types for terminology-related inputs.


### PR DESCRIPTION
Segmented Control in Mantine does not include an `<Input.Wrapper>`.