### PR TITLE
Make search proxy properties writable

### DIFF
--- a/.changeset/curly-dingos-fly.md
+++ b/.changeset/curly-dingos-fly.md
@@ -1,0 +1,5 @@
+---
+"@bonfhir/core": patch
+---
+
+Make proxy properties writable

--- a/packages/core/src/r4b/bundle-navigator.ts
+++ b/packages/core/src/r4b/bundle-navigator.ts
@@ -550,7 +550,7 @@ function withResolvableProxy<T extends Resource>(
         return {
           configurable: true,
           enumerable: true,
-          writable: false,
+          writable: true,
           value: (customResourceClass: any) =>
             navigator.reference(
               (target as Reference)?.reference,
@@ -563,7 +563,7 @@ function withResolvableProxy<T extends Resource>(
         return {
           configurable: true,
           enumerable: true,
-          writable: false,
+          writable: true,
           value: (
             select: (
               resource: any,
@@ -578,7 +578,7 @@ function withResolvableProxy<T extends Resource>(
         return {
           configurable: true,
           enumerable: true,
-          writable: false,
+          writable: true,
           value: () => true,
         };
       }

--- a/packages/core/src/r5/bundle-navigator.ts
+++ b/packages/core/src/r5/bundle-navigator.ts
@@ -556,7 +556,7 @@ function withResolvableProxy<T extends Resource>(
         return {
           configurable: true,
           enumerable: true,
-          writable: false,
+          writable: true,
           value: (customResourceClass: any) =>
             navigator.reference(
               (target as Reference)?.reference,
@@ -569,7 +569,7 @@ function withResolvableProxy<T extends Resource>(
         return {
           configurable: true,
           enumerable: true,
-          writable: false,
+          writable: true,
           value: (
             select: (
               resource: any,
@@ -584,7 +584,7 @@ function withResolvableProxy<T extends Resource>(
         return {
           configurable: true,
           enumerable: true,
-          writable: false,
+          writable: true,
           value: () => true,
         };
       }


### PR DESCRIPTION
Some frameworks may use the proxies and manipulate them in unforseen ways (e.g. Mantine Forms).
Making the proxy propertes writable may mitigate some of the issues by letting them do what they want.