### PR TITLE
Customize subscription registration

### DIFF
--- a/.changeset/dry-dogs-bathe.md
+++ b/.changeset/dry-dogs-bathe.md
@@ -1,0 +1,5 @@
+---
+"@bonfhir/core": minor
+---
+
+Add `resourcesAreEqual` helper function to semantically compare resources

--- a/.changeset/seven-students-fetch.md
+++ b/.changeset/seven-students-fetch.md
@@ -1,0 +1,5 @@
+---
+"@bonfhir/subscriptions": minor
+---
+
+Fix #38 - Add `registration` option to allow customization of the registration

--- a/.changeset/silly-trees-unite.md
+++ b/.changeset/silly-trees-unite.md
@@ -1,0 +1,5 @@
+---
+"@bonfhir/next": minor
+---
+
+Update next package to align with subscriptions updates

--- a/.changeset/tricky-ghosts-raise.md
+++ b/.changeset/tricky-ghosts-raise.md
@@ -1,0 +1,5 @@
+---
+"@bonfhir/aws-lambda": minor
+---
+
+Update to FhirSubscriptionLogger

--- a/.changeset/wicked-guests-juggle.md
+++ b/.changeset/wicked-guests-juggle.md
@@ -1,0 +1,5 @@
+---
+"@bonfhir/core": patch
+---
+
+Fix a bug in `client.createOr` that prevented using a search function parameter

--- a/packages/aws-lambda/src/r4b/handler.ts
+++ b/packages/aws-lambda/src/r4b/handler.ts
@@ -1,7 +1,7 @@
 import { FhirClient, urlSafeConcat } from "@bonfhir/core/r4b";
 import {
   FhirSubscription,
-  SubscriptionLogger,
+  FhirSubscriptionLogger,
   registerSubscriptions,
 } from "@bonfhir/subscriptions/r4b";
 import type {
@@ -33,7 +33,7 @@ export interface AwsLambdaFhirSubscriptionsConfig {
   webhookSecret: string;
 
   /** Logger to use. Defaults to console. */
-  logger?: SubscriptionLogger | null | undefined;
+  logger?: FhirSubscriptionLogger | null | undefined;
 
   contentType?: string | null | undefined;
 }

--- a/packages/aws-lambda/src/r5/handler.ts
+++ b/packages/aws-lambda/src/r5/handler.ts
@@ -1,7 +1,7 @@
 import { FhirClient, urlSafeConcat } from "@bonfhir/core/r5";
 import {
   FhirSubscription,
-  SubscriptionLogger,
+  FhirSubscriptionLogger,
   registerSubscriptions,
 } from "@bonfhir/subscriptions/r5";
 import type {
@@ -33,7 +33,7 @@ export interface AwsLambdaFhirSubscriptionsConfig {
   webhookSecret: string;
 
   /** Logger to use. Defaults to console. */
-  logger?: SubscriptionLogger | null | undefined;
+  logger?: FhirSubscriptionLogger | null | undefined;
 
   contentType?: string | null | undefined;
 }

--- a/packages/core/src/r4b/fhir-client.ts
+++ b/packages/core/src/r4b/fhir-client.ts
@@ -23,6 +23,7 @@ import {
   TerminologyCapabilities,
 } from "./fhir-types.codegen";
 import { Formatter } from "./formatters";
+import { resourcesAreEqual } from "./lang-utils";
 import { merge } from "./merge";
 import { Merger } from "./mergers/index";
 import { JSONPatchBody } from "./patch";
@@ -619,25 +620,12 @@ export async function createOr<TResource extends AnyResource>(
     return [found as any, false];
   }
 
-  const {
-    id: foundId,
-    meta: foundMeta,
-    text: foundText,
-    ...foundContent
-  } = found as any;
-  const {
-    id: resourceId,
-    meta: resourceMeta,
-    text: resourceText,
-    ...resourceContent
-  } = resource as any;
-  if (JSON.stringify(foundContent) === JSON.stringify(resourceContent)) {
+  if (resourcesAreEqual(found, resource)) {
     return [found as any, false];
   }
 
   if (action === "replace") {
-    // eslint-disable-next-line @typescript-eslint/no-unused-vars
-    resource.id = foundId;
+    resource.id = found.id;
     return [await client.update(resource), true];
   }
 

--- a/packages/core/src/r4b/fhir-client.ts
+++ b/packages/core/src/r4b/fhir-client.ts
@@ -605,7 +605,7 @@ export async function createOr<TResource extends AnyResource>(
 
   const searchResult = await client.search(
     resource.resourceType,
-    finalSearch.toString(),
+    finalSearch as any,
   );
   const found = searchResult.bundle.entry?.[0]?.resource as
     | Retrieved<TResource>

--- a/packages/core/src/r4b/lang-utils.test.ts
+++ b/packages/core/src/r4b/lang-utils.test.ts
@@ -1,6 +1,9 @@
+import { build } from "./builders";
+import { Resource } from "./fhir-types.codegen";
 import {
   asArray,
   cleanFhirValues,
+  resourcesAreEqual,
   truncate,
   urlSafeConcat,
 } from "./lang-utils";
@@ -64,5 +67,47 @@ describe("lang-utils", () => {
     ])("%p == %p", (input, expected) => {
       expect(cleanFhirValues(input)).toEqual(expected);
     });
+  });
+
+  describe("resourcesAreEqual", () => {
+    it.each([
+      [build("Patient", { id: "1" }), build("Patient", { id: "2" }), true],
+      [
+        build("Patient", { id: "1", name: [{ family: "Doe" }] }),
+        build("Patient", { id: "2", name: [{ family: "Smith" }] }),
+        false,
+      ],
+      [
+        build("Patient", {
+          id: "1",
+          name: [{ family: "Doe" }],
+          birthDate: "2023-01-01",
+        }),
+        build("Patient", {
+          id: "2",
+          name: [{ family: "Doe" }],
+          birthDate: "2023-01-01",
+        }),
+        true,
+      ],
+      [
+        build("Patient", {
+          id: "1",
+          name: [{ family: "Doe" }],
+          birthDate: "2023-01-01",
+        }),
+        build("Patient", {
+          birthDate: "2023-01-01",
+          name: [{ family: "Doe" }],
+          id: "2",
+        }),
+        true,
+      ],
+    ] satisfies Array<[Resource, Resource, boolean]>)(
+      "%p == %p",
+      (a, b, expected) => {
+        expect(resourcesAreEqual(a, b)).toEqual(expected);
+      },
+    );
   });
 });

--- a/packages/core/src/r4b/lang-utils.ts
+++ b/packages/core/src/r4b/lang-utils.ts
@@ -2,7 +2,7 @@
  * This module is used to provide a set of utility functions for typescript
  */
 
-import { Period } from "./fhir-types.codegen";
+import { DomainResource, Period, Resource } from "./fhir-types.codegen";
 
 /**
  * Returns the given `value` as is if it satisfies `Array.isArray` or otherwise
@@ -426,3 +426,37 @@ export type DropFirst<T extends unknown[]> = T extends [infer _, ...infer U]
  */
 export type RemoveUnderscoreKeys<T extends PropertyKey> =
   T extends `_${infer _U}` ? never : T;
+
+/**
+ * Semantically compare 2 resources, ignoring the id, meta and text fields.
+ */
+export function resourcesAreEqual(
+  resourceA: Resource,
+  resourceB: Resource,
+): boolean {
+  const {
+    id: idA,
+    meta: metaA,
+    text: textA,
+    ...resourceAWithoutMeta
+  } = resourceA as DomainResource;
+  const {
+    id: idB,
+    meta: metaB,
+    text: textB,
+    ...resourceBWithoutMeta
+  } = resourceB as DomainResource;
+
+  return deepEqual(resourceAWithoutMeta, resourceBWithoutMeta);
+}
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+function deepEqual(x: any, y: any): boolean {
+  const ok = Object.keys,
+    tx = typeof x,
+    ty = typeof y;
+  return x && y && tx === "object" && tx === ty
+    ? ok(x).length === ok(y).length &&
+        ok(x).every((key) => deepEqual(x[key], y[key]))
+    : x === y;
+}

--- a/packages/core/src/r5/fhir-client.ts
+++ b/packages/core/src/r5/fhir-client.ts
@@ -23,6 +23,7 @@ import {
   TerminologyCapabilities,
 } from "./fhir-types.codegen";
 import { Formatter } from "./formatters";
+import { resourcesAreEqual } from "./lang-utils";
 import { merge } from "./merge";
 import { Merger } from "./mergers/index";
 import { JSONPatchBody } from "./patch";
@@ -619,25 +620,12 @@ export async function createOr<TResource extends AnyResource>(
     return [found as any, false];
   }
 
-  const {
-    id: foundId,
-    meta: foundMeta,
-    text: foundText,
-    ...foundContent
-  } = found as any;
-  const {
-    id: resourceId,
-    meta: resourceMeta,
-    text: resourceText,
-    ...resourceContent
-  } = resource as any;
-  if (JSON.stringify(foundContent) === JSON.stringify(resourceContent)) {
+  if (resourcesAreEqual(found, resource)) {
     return [found as any, false];
   }
 
   if (action === "replace") {
-    // eslint-disable-next-line @typescript-eslint/no-unused-vars
-    resource.id = foundId;
+    resource.id = found.id;
     return [await client.update(resource), true];
   }
 

--- a/packages/core/src/r5/fhir-client.ts
+++ b/packages/core/src/r5/fhir-client.ts
@@ -605,7 +605,7 @@ export async function createOr<TResource extends AnyResource>(
 
   const searchResult = await client.search(
     resource.resourceType,
-    finalSearch.toString(),
+    finalSearch as any,
   );
   const found = searchResult.bundle.entry?.[0]?.resource as
     | Retrieved<TResource>

--- a/packages/core/src/r5/lang-utils.test.ts
+++ b/packages/core/src/r5/lang-utils.test.ts
@@ -1,6 +1,9 @@
+import { build } from "./builders";
+import { Resource } from "./fhir-types.codegen";
 import {
   asArray,
   cleanFhirValues,
+  resourcesAreEqual,
   truncate,
   urlSafeConcat,
 } from "./lang-utils";
@@ -64,5 +67,47 @@ describe("lang-utils", () => {
     ])("%p == %p", (input, expected) => {
       expect(cleanFhirValues(input)).toEqual(expected);
     });
+  });
+
+  describe("resourcesAreEqual", () => {
+    it.each([
+      [build("Patient", { id: "1" }), build("Patient", { id: "2" }), true],
+      [
+        build("Patient", { id: "1", name: [{ family: "Doe" }] }),
+        build("Patient", { id: "2", name: [{ family: "Smith" }] }),
+        false,
+      ],
+      [
+        build("Patient", {
+          id: "1",
+          name: [{ family: "Doe" }],
+          birthDate: "2023-01-01",
+        }),
+        build("Patient", {
+          id: "2",
+          name: [{ family: "Doe" }],
+          birthDate: "2023-01-01",
+        }),
+        true,
+      ],
+      [
+        build("Patient", {
+          id: "1",
+          name: [{ family: "Doe" }],
+          birthDate: "2023-01-01",
+        }),
+        build("Patient", {
+          birthDate: "2023-01-01",
+          name: [{ family: "Doe" }],
+          id: "2",
+        }),
+        true,
+      ],
+    ] satisfies Array<[Resource, Resource, boolean]>)(
+      "%p == %p",
+      (a, b, expected) => {
+        expect(resourcesAreEqual(a, b)).toEqual(expected);
+      },
+    );
   });
 });

--- a/packages/core/src/r5/lang-utils.ts
+++ b/packages/core/src/r5/lang-utils.ts
@@ -2,7 +2,7 @@
  * This module is used to provide a set of utility functions for typescript
  */
 
-import { Period } from "./fhir-types.codegen";
+import { DomainResource, Period, Resource } from "./fhir-types.codegen";
 
 /**
  * Returns the given `value` as is if it satisfies `Array.isArray` or otherwise
@@ -426,3 +426,37 @@ export type DropFirst<T extends unknown[]> = T extends [infer _, ...infer U]
  */
 export type RemoveUnderscoreKeys<T extends PropertyKey> =
   T extends `_${infer _U}` ? never : T;
+
+/**
+ * Semantically compare 2 resources, ignoring the id, meta and text fields.
+ */
+export function resourcesAreEqual(
+  resourceA: Resource,
+  resourceB: Resource,
+): boolean {
+  const {
+    id: idA,
+    meta: metaA,
+    text: textA,
+    ...resourceAWithoutMeta
+  } = resourceA as DomainResource;
+  const {
+    id: idB,
+    meta: metaB,
+    text: textB,
+    ...resourceBWithoutMeta
+  } = resourceB as DomainResource;
+
+  return deepEqual(resourceAWithoutMeta, resourceBWithoutMeta);
+}
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+function deepEqual(x: any, y: any): boolean {
+  const ok = Object.keys,
+    tx = typeof x,
+    ty = typeof y;
+  return x && y && tx === "object" && tx === ty
+    ? ok(x).length === ok(y).length &&
+        ok(x).every((key) => deepEqual(x[key], y[key]))
+    : x === y;
+}

--- a/packages/next/src/r4b/server/subscriptions/middleware.ts
+++ b/packages/next/src/r4b/server/subscriptions/middleware.ts
@@ -1,7 +1,7 @@
 import { FhirClient, urlSafeConcat } from "@bonfhir/core/r4b";
 import {
   FhirSubscription,
-  SubscriptionLogger,
+  FhirSubscriptionLogger,
   registerSubscriptions,
 } from "@bonfhir/subscriptions/r4b";
 import { NextMiddleware, NextResponse } from "next/server.js";
@@ -31,7 +31,7 @@ export interface FhirSubscriptionsConfig {
   webhookSecret: string;
 
   /** Logger to use. Defaults to console. */
-  logger?: SubscriptionLogger | null | undefined;
+  logger?: FhirSubscriptionLogger | null | undefined;
 
   contentType?: string | null | undefined;
 }

--- a/packages/next/src/r5/server/subscriptions/middleware.ts
+++ b/packages/next/src/r5/server/subscriptions/middleware.ts
@@ -1,7 +1,7 @@
 import { FhirClient, urlSafeConcat } from "@bonfhir/core/r5";
 import {
   FhirSubscription,
-  SubscriptionLogger,
+  FhirSubscriptionLogger,
   registerSubscriptions,
 } from "@bonfhir/subscriptions/r5";
 import { NextMiddleware, NextResponse } from "next/server.js";
@@ -31,7 +31,7 @@ export interface FhirSubscriptionsConfig {
   webhookSecret: string;
 
   /** Logger to use. Defaults to console. */
-  logger?: SubscriptionLogger | null | undefined;
+  logger?: FhirSubscriptionLogger | null | undefined;
 
   contentType?: string | null | undefined;
 }

--- a/packages/subscriptions/src/r5/__fhir-subscription.ts
+++ b/packages/subscriptions/src/r5/__fhir-subscription.ts
@@ -26,6 +26,11 @@ export type FhirSubscriptionHandler<
   args: FhirSubscriptionHandlerArgs<TResource>,
 ) => Promise<FhirSubscriptionHandlerResult>;
 
+export type FhirSubscriptionLogger = Pick<
+  typeof console,
+  "debug" | "info" | "warn" | "error"
+>;
+
 export interface FhirSubscriptionHandlerArgs<
   TResource extends AnyResource = AnyResource,
 > {
@@ -35,10 +40,7 @@ export interface FhirSubscriptionHandlerArgs<
   resource: Retrieved<TResource>;
 
   /** The configured logger. */
-  logger:
-    | Pick<typeof console, "debug" | "info" | "warn" | "error">
-    | null
-    | undefined;
+  logger: FhirSubscriptionLogger | null | undefined;
 }
 
 export type FhirSubscriptionHandlerResult =
@@ -47,15 +49,10 @@ export type FhirSubscriptionHandlerResult =
   | object
   | Promise<object>;
 
-export type SubscriptionLogger = Pick<
-  typeof console,
-  "debug" | "info" | "warn" | "error"
->;
-
 export interface RegisterSubscriptionsArgs {
   fhirClient: FhirClient;
 
-  logger: SubscriptionLogger;
+  logger: FhirSubscriptionLogger;
 
   /** The API base URL */
   baseUrl: string;

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -22,13 +22,13 @@ importers:
         version: 2.26.2
       '@graphql-codegen/cli':
         specifier: ^5.0.0
-        version: 5.0.0(graphql@16.7.1)
+        version: 5.0.0(@parcel/watcher@2.2.0)(@types/node@18.17.1)(graphql@16.7.1)
       graphql:
         specifier: ^16.7.1
         version: 16.7.1
       graphql-config:
         specifier: ^5.0.2
-        version: 5.0.2(graphql@16.7.1)
+        version: 5.0.2(@types/node@18.17.1)(graphql@16.7.1)
       turbo:
         specifier: ^1.10.13
         version: 1.10.13
@@ -2061,7 +2061,7 @@ packages:
       '@babel/traverse': 7.22.8
       '@babel/types': 7.22.5
       convert-source-map: 1.9.0
-      debug: 4.3.4(supports-color@8.1.1)
+      debug: 4.3.4
       gensync: 1.0.0-beta.2
       json5: 2.2.3
       semver: 7.5.4
@@ -5251,61 +5251,6 @@ packages:
       - utf-8-validate
     dev: true
 
-  /@graphql-codegen/cli@5.0.0(graphql@16.7.1):
-    resolution: {integrity: sha512-A7J7+be/a6e+/ul2KI5sfJlpoqeqwX8EzktaKCeduyVKgOLA6W5t+NUGf6QumBDXU8PEOqXk3o3F+RAwCWOiqA==}
-    hasBin: true
-    peerDependencies:
-      '@parcel/watcher': ^2.1.0
-      graphql: ^0.8.0 || ^0.9.0 || ^0.10.0 || ^0.11.0 || ^0.12.0 || ^0.13.0 || ^14.0.0 || ^15.0.0 || ^16.0.0
-    peerDependenciesMeta:
-      '@parcel/watcher':
-        optional: true
-    dependencies:
-      '@babel/generator': 7.22.9
-      '@babel/template': 7.22.5
-      '@babel/types': 7.22.5
-      '@graphql-codegen/core': 4.0.0(graphql@16.7.1)
-      '@graphql-codegen/plugin-helpers': 5.0.1(graphql@16.7.1)
-      '@graphql-tools/apollo-engine-loader': 8.0.0(graphql@16.7.1)
-      '@graphql-tools/code-file-loader': 8.0.2(graphql@16.7.1)
-      '@graphql-tools/git-loader': 8.0.2(graphql@16.7.1)
-      '@graphql-tools/github-loader': 8.0.0(graphql@16.7.1)
-      '@graphql-tools/graphql-file-loader': 8.0.0(graphql@16.7.1)
-      '@graphql-tools/json-file-loader': 8.0.0(graphql@16.7.1)
-      '@graphql-tools/load': 8.0.0(graphql@16.7.1)
-      '@graphql-tools/prisma-loader': 8.0.1(graphql@16.7.1)
-      '@graphql-tools/url-loader': 8.0.0(graphql@16.7.1)
-      '@graphql-tools/utils': 10.0.4(graphql@16.7.1)
-      '@whatwg-node/fetch': 0.8.8
-      chalk: 4.1.2
-      cosmiconfig: 8.2.0
-      debounce: 1.2.1
-      detect-indent: 6.1.0
-      graphql: 16.7.1
-      graphql-config: 5.0.2(graphql@16.7.1)
-      inquirer: 8.2.5
-      is-glob: 4.0.3
-      jiti: 1.19.1
-      json-to-pretty-yaml: 1.2.2
-      listr2: 4.0.5
-      log-symbols: 4.1.0
-      micromatch: 4.0.5
-      shell-quote: 1.8.1
-      string-env-interpolation: 1.0.1
-      ts-log: 2.2.5
-      tslib: 2.6.1
-      yaml: 2.3.1
-      yargs: 17.7.2
-    transitivePeerDependencies:
-      - '@types/node'
-      - bufferutil
-      - cosmiconfig-toml-loader
-      - encoding
-      - enquirer
-      - supports-color
-      - utf-8-validate
-    dev: true
-
   /@graphql-codegen/core@4.0.0(graphql@16.7.1):
     resolution: {integrity: sha512-JAGRn49lEtSsZVxeIlFVIRxts2lWObR+OQo7V2LHDJ7ohYYw3ilv7nJ8pf8P4GTg/w6ptcYdSdVVdkI8kUHB/Q==}
     peerDependencies:
@@ -5588,24 +5533,6 @@ packages:
       - '@types/node'
     dev: true
 
-  /@graphql-tools/executor-http@1.0.2(graphql@16.7.1):
-    resolution: {integrity: sha512-JKTB4E3kdQM2/1NEcyrVPyQ8057ZVthCV5dFJiKktqY9IdmF00M8gupFcW3jlbM/Udn78ickeUBsUzA3EouqpA==}
-    engines: {node: '>=16.0.0'}
-    peerDependencies:
-      graphql: ^14.0.0 || ^15.0.0 || ^16.0.0 || ^17.0.0
-    dependencies:
-      '@graphql-tools/utils': 10.0.4(graphql@16.7.1)
-      '@repeaterjs/repeater': 3.0.4
-      '@whatwg-node/fetch': 0.9.9
-      extract-files: 11.0.0
-      graphql: 16.7.1
-      meros: 1.3.0
-      tslib: 2.6.1
-      value-or-promise: 1.0.12
-    transitivePeerDependencies:
-      - '@types/node'
-    dev: true
-
   /@graphql-tools/executor-legacy-ws@1.0.1(graphql@16.7.1):
     resolution: {integrity: sha512-PQrTJ+ncHMEQspBARc2lhwiQFfRAX/z/CsOdZTFjIljOHgRWGAA1DAx7pEN0j6PflbLCfZ3NensNq2jCBwF46w==}
     engines: {node: '>=16.0.0'}
@@ -5662,26 +5589,6 @@ packages:
     dependencies:
       '@ardatan/sync-fetch': 0.0.1
       '@graphql-tools/executor-http': 1.0.2(@types/node@18.17.1)(graphql@16.7.1)
-      '@graphql-tools/graphql-tag-pluck': 8.0.2(graphql@16.7.1)
-      '@graphql-tools/utils': 10.0.4(graphql@16.7.1)
-      '@whatwg-node/fetch': 0.9.9
-      graphql: 16.7.1
-      tslib: 2.6.1
-      value-or-promise: 1.0.12
-    transitivePeerDependencies:
-      - '@types/node'
-      - encoding
-      - supports-color
-    dev: true
-
-  /@graphql-tools/github-loader@8.0.0(graphql@16.7.1):
-    resolution: {integrity: sha512-VuroArWKcG4yaOWzV0r19ElVIV6iH6UKDQn1MXemND0xu5TzrFme0kf3U9o0YwNo0kUYEk9CyFM0BYg4he17FA==}
-    engines: {node: '>=16.0.0'}
-    peerDependencies:
-      graphql: ^14.0.0 || ^15.0.0 || ^16.0.0 || ^17.0.0
-    dependencies:
-      '@ardatan/sync-fetch': 0.0.1
-      '@graphql-tools/executor-http': 1.0.2(graphql@16.7.1)
       '@graphql-tools/graphql-tag-pluck': 8.0.2(graphql@16.7.1)
       '@graphql-tools/utils': 10.0.4(graphql@16.7.1)
       '@whatwg-node/fetch': 0.9.9
@@ -5827,39 +5734,6 @@ packages:
       - utf-8-validate
     dev: true
 
-  /@graphql-tools/prisma-loader@8.0.1(graphql@16.7.1):
-    resolution: {integrity: sha512-bl6e5sAYe35Z6fEbgKXNrqRhXlCJYeWKBkarohgYA338/SD9eEhXtg3Cedj7fut3WyRLoQFpHzfiwxKs7XrgXg==}
-    engines: {node: '>=16.0.0'}
-    peerDependencies:
-      graphql: ^14.0.0 || ^15.0.0 || ^16.0.0 || ^17.0.0
-    dependencies:
-      '@graphql-tools/url-loader': 8.0.0(graphql@16.7.1)
-      '@graphql-tools/utils': 10.0.4(graphql@16.7.1)
-      '@types/js-yaml': 4.0.5
-      '@types/json-stable-stringify': 1.0.34
-      '@whatwg-node/fetch': 0.9.9
-      chalk: 4.1.2
-      debug: 4.3.4
-      dotenv: 16.3.1
-      graphql: 16.7.1
-      graphql-request: 6.1.0(graphql@16.7.1)
-      http-proxy-agent: 7.0.0
-      https-proxy-agent: 7.0.1
-      jose: 4.14.4
-      js-yaml: 4.1.0
-      json-stable-stringify: 1.0.2
-      lodash: 4.17.21
-      scuid: 1.1.0
-      tslib: 2.6.1
-      yaml-ast-parser: 0.0.43
-    transitivePeerDependencies:
-      - '@types/node'
-      - bufferutil
-      - encoding
-      - supports-color
-      - utf-8-validate
-    dev: true
-
   /@graphql-tools/relay-operation-optimizer@6.5.18(graphql@16.7.1):
     resolution: {integrity: sha512-mc5VPyTeV+LwiM+DNvoDQfPqwQYhPV/cl5jOBjTgSniyaq8/86aODfMkrE2OduhQ5E00hqrkuL2Fdrgk0w1QJg==}
     peerDependencies:
@@ -5912,33 +5786,6 @@ packages:
       '@graphql-tools/delegate': 10.0.0(graphql@16.7.1)
       '@graphql-tools/executor-graphql-ws': 1.1.0(graphql@16.7.1)
       '@graphql-tools/executor-http': 1.0.2(@types/node@18.17.1)(graphql@16.7.1)
-      '@graphql-tools/executor-legacy-ws': 1.0.1(graphql@16.7.1)
-      '@graphql-tools/utils': 10.0.4(graphql@16.7.1)
-      '@graphql-tools/wrap': 10.0.0(graphql@16.7.1)
-      '@types/ws': 8.5.5
-      '@whatwg-node/fetch': 0.9.9
-      graphql: 16.7.1
-      isomorphic-ws: 5.0.0(ws@8.13.0)
-      tslib: 2.6.1
-      value-or-promise: 1.0.12
-      ws: 8.13.0
-    transitivePeerDependencies:
-      - '@types/node'
-      - bufferutil
-      - encoding
-      - utf-8-validate
-    dev: true
-
-  /@graphql-tools/url-loader@8.0.0(graphql@16.7.1):
-    resolution: {integrity: sha512-rPc9oDzMnycvz+X+wrN3PLrhMBQkG4+sd8EzaFN6dypcssiefgWKToXtRKI8HHK68n2xEq1PyrOpkjHFJB+GwA==}
-    engines: {node: '>=16.0.0'}
-    peerDependencies:
-      graphql: ^14.0.0 || ^15.0.0 || ^16.0.0 || ^17.0.0
-    dependencies:
-      '@ardatan/sync-fetch': 0.0.1
-      '@graphql-tools/delegate': 10.0.0(graphql@16.7.1)
-      '@graphql-tools/executor-graphql-ws': 1.1.0(graphql@16.7.1)
-      '@graphql-tools/executor-http': 1.0.2(graphql@16.7.1)
       '@graphql-tools/executor-legacy-ws': 1.0.1(graphql@16.7.1)
       '@graphql-tools/utils': 10.0.4(graphql@16.7.1)
       '@graphql-tools/wrap': 10.0.0(graphql@16.7.1)
@@ -6375,6 +6222,49 @@ packages:
       - supports-color
       - ts-node
       - utf-8-validate
+    dev: true
+
+  /@jest/core@29.6.2:
+    resolution: {integrity: sha512-Oj+5B+sDMiMWLhPFF+4/DvHOf+U10rgvCLGPHP8Xlsy/7QxS51aU/eBngudHlJXnaWD5EohAgJ4js+T6pa+zOg==}
+    engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
+    peerDependencies:
+      node-notifier: ^8.0.1 || ^9.0.0 || ^10.0.0
+    peerDependenciesMeta:
+      node-notifier:
+        optional: true
+    dependencies:
+      '@jest/console': 29.6.2
+      '@jest/reporters': 29.6.2
+      '@jest/test-result': 29.6.2
+      '@jest/transform': 29.6.2
+      '@jest/types': 29.6.1
+      '@types/node': 18.17.1
+      ansi-escapes: 4.3.2
+      chalk: 4.1.2
+      ci-info: 3.8.0
+      exit: 0.1.2
+      graceful-fs: 4.2.11
+      jest-changed-files: 29.5.0
+      jest-config: 29.6.2(@types/node@18.17.1)
+      jest-haste-map: 29.6.2
+      jest-message-util: 29.6.2
+      jest-regex-util: 29.4.3
+      jest-resolve: 29.6.2
+      jest-resolve-dependencies: 29.6.2
+      jest-runner: 29.6.2
+      jest-runtime: 29.6.2
+      jest-snapshot: 29.6.2
+      jest-util: 29.6.2
+      jest-validate: 29.6.2
+      jest-watcher: 29.6.2
+      micromatch: 4.0.5
+      pretty-format: 29.6.2
+      slash: 3.0.0
+      strip-ansi: 6.0.1
+    transitivePeerDependencies:
+      - babel-plugin-macros
+      - supports-color
+      - ts-node
     dev: true
 
   /@jest/core@29.6.2(ts-node@10.9.1):
@@ -7120,7 +7010,7 @@ packages:
       '@open-draft/until': 1.0.3
       '@types/debug': 4.1.8
       '@xmldom/xmldom': 0.8.10
-      debug: 4.3.4(supports-color@8.1.1)
+      debug: 4.3.4
       headers-polyfill: 3.1.2
       outvariant: 1.4.0
       strict-event-emitter: 0.2.8
@@ -11895,6 +11785,15 @@ packages:
     engines: {node: '>= 6.0.0'}
     dev: true
 
+  /agent-base@6.0.2:
+    resolution: {integrity: sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ==}
+    engines: {node: '>= 6.0.0'}
+    dependencies:
+      debug: 4.3.4
+    transitivePeerDependencies:
+      - supports-color
+    dev: true
+
   /agent-base@6.0.2(supports-color@8.1.1):
     resolution: {integrity: sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ==}
     engines: {node: '>= 6.0.0'}
@@ -11908,7 +11807,7 @@ packages:
     resolution: {integrity: sha512-o/zjMZRhJxny7OyEF+Op8X+efiELC7k7yOjMzgfzVqOzXqkBkWI79YoTdOtsuWd5BWhAGAuOY/Xa6xpiaWXiNg==}
     engines: {node: '>= 14'}
     dependencies:
-      debug: 4.3.4
+      debug: 4.3.4(supports-color@8.1.1)
     transitivePeerDependencies:
       - supports-color
     dev: true
@@ -11917,7 +11816,7 @@ packages:
     resolution: {integrity: sha512-7Epl1Blf4Sy37j4v9f9FjICCh4+KAQOyXgHEwlyBiAQLbhKdq/i2QQU3amQalS/wPhdPzDXPL5DMR5bkn+YeWg==}
     engines: {node: '>= 8.0.0'}
     dependencies:
-      debug: 4.3.4(supports-color@8.1.1)
+      debug: 4.3.4
       depd: 2.0.0
       humanize-ms: 1.2.1
     transitivePeerDependencies:
@@ -16965,35 +16864,6 @@ packages:
       - utf-8-validate
     dev: true
 
-  /graphql-config@5.0.2(graphql@16.7.1):
-    resolution: {integrity: sha512-7TPxOrlbiG0JplSZYCyxn2XQtqVhXomEjXUmWJVSS5ET1nPhOJSsIb/WTwqWhcYX6G0RlHXSj9PLtGTKmxLNGg==}
-    engines: {node: '>= 16.0.0'}
-    peerDependencies:
-      cosmiconfig-toml-loader: ^1.0.0
-      graphql: ^0.11.0 || ^0.12.0 || ^0.13.0 || ^14.0.0 || ^15.0.0 || ^16.0.0
-    peerDependenciesMeta:
-      cosmiconfig-toml-loader:
-        optional: true
-    dependencies:
-      '@graphql-tools/graphql-file-loader': 8.0.0(graphql@16.7.1)
-      '@graphql-tools/json-file-loader': 8.0.0(graphql@16.7.1)
-      '@graphql-tools/load': 8.0.0(graphql@16.7.1)
-      '@graphql-tools/merge': 9.0.0(graphql@16.7.1)
-      '@graphql-tools/url-loader': 8.0.0(graphql@16.7.1)
-      '@graphql-tools/utils': 10.0.4(graphql@16.7.1)
-      cosmiconfig: 8.2.0
-      graphql: 16.7.1
-      jiti: 1.19.1
-      minimatch: 4.2.3
-      string-env-interpolation: 1.0.1
-      tslib: 2.6.1
-    transitivePeerDependencies:
-      - '@types/node'
-      - bufferutil
-      - encoding
-      - utf-8-validate
-    dev: true
-
   /graphql-request@6.1.0(graphql@16.7.1):
     resolution: {integrity: sha512-p+XPfS4q7aIpKVcgmnZKhMNqhltk20hfXtkaIkTfjjmiKMJ5xrt5c743cL03y/K7y1rg3WrIC49xGiEQ4mxdNw==}
     peerDependencies:
@@ -17401,8 +17271,8 @@ packages:
     engines: {node: '>= 6'}
     dependencies:
       '@tootallnate/once': 2.0.0
-      agent-base: 6.0.2(supports-color@8.1.1)
-      debug: 4.3.4(supports-color@8.1.1)
+      agent-base: 6.0.2
+      debug: 4.3.4
     transitivePeerDependencies:
       - supports-color
     dev: true
@@ -17412,7 +17282,7 @@ packages:
     engines: {node: '>= 14'}
     dependencies:
       agent-base: 7.1.0
-      debug: 4.3.4
+      debug: 4.3.4(supports-color@8.1.1)
     transitivePeerDependencies:
       - supports-color
     dev: true
@@ -17463,6 +17333,16 @@ packages:
       - supports-color
     dev: true
 
+  /https-proxy-agent@5.0.1:
+    resolution: {integrity: sha512-dFcAjpTQFgoLMzC2VwU+C/CbS7uRL0lWmxDITmqm7C+7F0Odmj6s9l6alZc6AELXhrnggM2CeWSXHGOdX2YtwA==}
+    engines: {node: '>= 6'}
+    dependencies:
+      agent-base: 6.0.2
+      debug: 4.3.4
+    transitivePeerDependencies:
+      - supports-color
+    dev: true
+
   /https-proxy-agent@5.0.1(supports-color@8.1.1):
     resolution: {integrity: sha512-dFcAjpTQFgoLMzC2VwU+C/CbS7uRL0lWmxDITmqm7C+7F0Odmj6s9l6alZc6AELXhrnggM2CeWSXHGOdX2YtwA==}
     engines: {node: '>= 6'}
@@ -17478,7 +17358,7 @@ packages:
     engines: {node: '>= 14'}
     dependencies:
       agent-base: 7.1.0
-      debug: 4.3.4
+      debug: 4.3.4(supports-color@8.1.1)
     transitivePeerDependencies:
       - supports-color
     dev: true
@@ -18215,7 +18095,7 @@ packages:
     resolution: {integrity: sha512-n3s8EwkdFIJCG3BPKBYvskgXGoy88ARzvegkitk60NxRdwltLOTaH7CUiMRXvwYorl0Q712iEjcWB+fK/MrWVw==}
     engines: {node: '>=10'}
     dependencies:
-      debug: 4.3.4(supports-color@8.1.1)
+      debug: 4.3.4
       istanbul-lib-coverage: 3.2.0
       source-map: 0.6.1
     transitivePeerDependencies:
@@ -18368,14 +18248,14 @@ packages:
       node-notifier:
         optional: true
     dependencies:
-      '@jest/core': 29.6.2(ts-node@10.9.1)
+      '@jest/core': 29.6.2
       '@jest/test-result': 29.6.2
       '@jest/types': 29.6.1
       chalk: 4.1.2
       exit: 0.1.2
       graceful-fs: 4.2.11
       import-local: 3.1.0
-      jest-config: 29.6.2(@types/node@18.17.1)(ts-node@10.9.1)
+      jest-config: 29.6.2(@types/node@18.17.1)
       jest-util: 29.6.2
       jest-validate: 29.6.2
       prompts: 2.4.2
@@ -18454,6 +18334,46 @@ packages:
       - canvas
       - supports-color
       - utf-8-validate
+    dev: true
+
+  /jest-config@29.6.2(@types/node@18.17.1):
+    resolution: {integrity: sha512-VxwFOC8gkiJbuodG9CPtMRjBUNZEHxwfQXmIudSTzFWxaci3Qub1ddTRbFNQlD/zUeaifLndh/eDccFX4wCMQw==}
+    engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
+    peerDependencies:
+      '@types/node': '*'
+      ts-node: '>=9.0.0'
+    peerDependenciesMeta:
+      '@types/node':
+        optional: true
+      ts-node:
+        optional: true
+    dependencies:
+      '@babel/core': 7.22.9
+      '@jest/test-sequencer': 29.6.2
+      '@jest/types': 29.6.1
+      '@types/node': 18.17.1
+      babel-jest: 29.6.2(@babel/core@7.22.9)
+      chalk: 4.1.2
+      ci-info: 3.8.0
+      deepmerge: 4.3.1
+      glob: 7.2.3
+      graceful-fs: 4.2.11
+      jest-circus: 29.6.2
+      jest-environment-node: 29.6.2
+      jest-get-type: 29.4.3
+      jest-regex-util: 29.4.3
+      jest-resolve: 29.6.2
+      jest-runner: 29.6.2
+      jest-util: 29.6.2
+      jest-validate: 29.6.2
+      micromatch: 4.0.5
+      parse-json: 5.2.0
+      pretty-format: 29.6.2
+      slash: 3.0.0
+      strip-json-comments: 3.1.1
+    transitivePeerDependencies:
+      - babel-plugin-macros
+      - supports-color
     dev: true
 
   /jest-config@29.6.2(@types/node@18.17.1)(ts-node@10.9.1):
@@ -19307,7 +19227,7 @@ packages:
       node-notifier:
         optional: true
     dependencies:
-      '@jest/core': 29.6.2(ts-node@10.9.1)
+      '@jest/core': 29.6.2
       '@jest/types': 29.6.1
       import-local: 3.1.0
       jest-cli: 29.6.2(@types/node@18.17.1)
@@ -20103,7 +20023,7 @@ packages:
       cacache: 16.1.3
       http-cache-semantics: 4.1.1
       http-proxy-agent: 5.0.0
-      https-proxy-agent: 5.0.1(supports-color@8.1.1)
+      https-proxy-agent: 5.0.1
       is-lambda: 1.0.1
       lru-cache: 7.18.3
       minipass: 3.3.6
@@ -20128,7 +20048,7 @@ packages:
       cacache: 17.1.0
       http-cache-semantics: 4.1.1
       http-proxy-agent: 5.0.0
-      https-proxy-agent: 5.0.1(supports-color@8.1.1)
+      https-proxy-agent: 5.0.1
       is-lambda: 1.0.1
       lru-cache: 7.18.3
       minipass: 5.0.0
@@ -20297,16 +20217,6 @@ packages:
   /merge2@1.4.1:
     resolution: {integrity: sha512-8q7VEgMJW4J8tcfVPy8g09NcQwZdbwFEqhe/WZkoIzjn/3TGDwtOCYtXGxA3O8tPzpczCCDgv+P2P5y00ZJOOg==}
     engines: {node: '>= 8'}
-
-  /meros@1.3.0:
-    resolution: {integrity: sha512-2BNGOimxEz5hmjUG2FwoxCt5HN7BXdaWyFqEwxPTrJzVdABtrL4TiHTcsWSFAxPQ/tOnEaQEJh3qWq71QRMY+w==}
-    engines: {node: '>=13'}
-    peerDependencies:
-      '@types/node': '>=13'
-    peerDependenciesMeta:
-      '@types/node':
-        optional: true
-    dev: true
 
   /meros@1.3.0(@types/node@18.17.1):
     resolution: {integrity: sha512-2BNGOimxEz5hmjUG2FwoxCt5HN7BXdaWyFqEwxPTrJzVdABtrL4TiHTcsWSFAxPQ/tOnEaQEJh3qWq71QRMY+w==}
@@ -24845,8 +24755,8 @@ packages:
     resolution: {integrity: sha512-Fgl0YPZ902wEsAyiQ+idGd1A7rSFx/ayC1CQVMw5P+EQx2V0SgpGtf6OKFhVjPflPUl9YMmEOnmfjCdMUsygww==}
     engines: {node: '>= 10'}
     dependencies:
-      agent-base: 6.0.2(supports-color@8.1.1)
-      debug: 4.3.4(supports-color@8.1.1)
+      agent-base: 6.0.2
+      debug: 4.3.4
       socks: 2.7.1
     transitivePeerDependencies:
       - supports-color
@@ -26050,7 +25960,7 @@ packages:
     engines: {node: ^14.17.0 || ^16.13.0 || >=18.0.0}
     dependencies:
       '@tufjs/models': 1.0.4
-      debug: 4.3.4(supports-color@8.1.1)
+      debug: 4.3.4
       make-fetch-happen: 11.1.1
     transitivePeerDependencies:
       - supports-color


### PR DESCRIPTION
This PR adds the possibility to customize the subscription registration - Fix #38.

It also incidentally have:
 - the addition of a `resourcesAreEqual` core function to compare resources semantically
 - a bug fix on the `client.createOr` function that prevented using a custom search function
 - some renaming / consolidation around the `FhirSubscriptionLogger`