### PR TITLE
Chore add cli ascii art

### DIFF
--- a/.changeset/kind-spies-lay.md
+++ b/.changeset/kind-spies-lay.md
@@ -1,0 +1,6 @@
+---
+"@bonfhir/cli": patch
+"create-bonfhir": patch
+---
+
+Update the bonFHIR logo in CLI

--- a/packages/cli/src/ascii-logo.ts
+++ b/packages/cli/src/ascii-logo.ts
@@ -1,0 +1,19 @@
+// prints ASCII bonFIHR logo to the console
+export default function writeLogo() {
+  console.log(
+    "       |\\         _                    _____  _   _  ___  ____        |\\",
+  );
+  console.log(
+    "       | V\\      | |__    ___   _ __  |  ___|| | | ||_ _||  _ \\       | V\\",
+  );
+  console.log(
+    "    \\  /  / \\    | '_ \\  / _ \\ | '_ \\ | |_   | |_| | | | | |_) |   \\  /  / \\",
+  );
+  console.log(
+    "    |\\/   \\_|\\   | |_) || (_) || | | ||  _|  |  _  | | | |  _ <    |\\/   \\_|\\",
+  );
+  console.log(
+    "     \\_______/   |_.__/  \\___/ |_| |_||_|    |_| |_||___||_| \\_\\    \\_______/",
+  );
+  console.log("\n");
+}

--- a/packages/cli/src/commands/create.ts
+++ b/packages/cli/src/commands/create.ts
@@ -1,6 +1,6 @@
-import chalk from "chalk";
 import inquirer from "inquirer";
 import { CommandModule } from "yargs";
+import writeLogo from "../ascii-logo";
 import { Templates } from "../templates";
 import {
   PackageManager,
@@ -37,8 +37,7 @@ export default <CommandModule<unknown, CommandOption>>{
     },
   },
   handler: async (options) => {
-    console.log(chalk.bold(`🔥 BonFHIR 🔥`));
-    console.log();
+    writeLogo();
 
     const answers: Required<CommandOption> = await inquirer.prompt(
       [


### PR DESCRIPTION
This PR adds some simple ASCII art of the bonFHIR logo to liven up the display text in the command-line interface. Figlet was used as a tool to generate the initial text, which was modified with the addition of some original "fire" text. The resulting text does not use any libraries and is simply delivered via console.log() commands. 

Please note the ASCII image will not be legible in code due to the need for escape sequences. To validate, please run the command line tool on this branch. 