### PR TITLE
Add optional buttons to questionnaire

### DIFF
--- a/.changeset/rotten-bugs-move.md
+++ b/.changeset/rotten-bugs-move.md
@@ -1,0 +1,6 @@
+---
+"@bonfhir/mantine": minor
+"@bonfhir/react": minor
+---
+
+add optional button props to the Fhir Questionnaire

--- a/packages/mantine/src/r4b/inputs/fhir-questionnaire.tsx
+++ b/packages/mantine/src/r4b/inputs/fhir-questionnaire.tsx
@@ -121,24 +121,7 @@ export function MantineFhirQuestionnaire(
           <Button type="submit" {...props.rendererProps?.submit}>
             {props.rendererProps?.submitText || "Submit"}
           </Button>
-          {props.onDraft && (
-            <Button
-              variant="outline"
-              onClick={props.onDraft}
-              {...props.rendererProps?.draft}
-            >
-              {props.rendererProps?.draftText || "Save as draft"}
-            </Button>
-          )}
-          {props.onDelete && (
-            <Button
-              color="red"
-              onClick={props.onDelete}
-              {...props.rendererProps?.delete}
-            >
-              {props.rendererProps?.deleteText || "Delete"}
-            </Button>
-          )}
+          {props.additionalButtons && props.additionalButtons}
           {props.onCancel && (
             <Button
               variant="outline"
@@ -164,10 +147,7 @@ export interface MantineFhirQuestionnaireProps {
   itemInput?: FhirInputProps | null | undefined;
   submit?: ButtonProps | null | undefined;
   submitText?: ReactNode | null | undefined;
-  cancel?: ButtonProps | null | undefined;
-  cancelText?: ReactNode | null | undefined;
-  draft?: ButtonProps | null | undefined;
-  draftText?: ReactNode | null | undefined;
+  additionalButtons?: ReactElement | null | undefined;
   delete?: ButtonProps | null | undefined;
   deleteText?: ReactNode | null | undefined;
 }

--- a/packages/mantine/src/r4b/inputs/fhir-questionnaire.tsx
+++ b/packages/mantine/src/r4b/inputs/fhir-questionnaire.tsx
@@ -121,6 +121,24 @@ export function MantineFhirQuestionnaire(
           <Button type="submit" {...props.rendererProps?.submit}>
             {props.rendererProps?.submitText || "Submit"}
           </Button>
+          {props.onDraft && (
+            <Button
+              variant="outline"
+              onClick={props.onDraft}
+              {...props.rendererProps?.draft}
+            >
+              {props.rendererProps?.draftText || "Save as draft"}
+            </Button>
+          )}
+          {props.onDelete && (
+            <Button
+              color="red"
+              onClick={props.onDelete}
+              {...props.rendererProps?.delete}
+            >
+              {props.rendererProps?.deleteText || "Delete"}
+            </Button>
+          )}
           {props.onCancel && (
             <Button
               variant="outline"
@@ -148,6 +166,10 @@ export interface MantineFhirQuestionnaireProps {
   submitText?: ReactNode | null | undefined;
   cancel?: ButtonProps | null | undefined;
   cancelText?: ReactNode | null | undefined;
+  draft?: ButtonProps | null | undefined;
+  draftText?: ReactNode | null | undefined;
+  delete?: ButtonProps | null | undefined;
+  deleteText?: ReactNode | null | undefined;
 }
 
 function MantineQuestionnaireItemRenderer({

--- a/packages/mantine/src/r4b/inputs/fhir-questionnaire.tsx
+++ b/packages/mantine/src/r4b/inputs/fhir-questionnaire.tsx
@@ -148,8 +148,8 @@ export interface MantineFhirQuestionnaireProps {
   submit?: ButtonProps | null | undefined;
   submitText?: ReactNode | null | undefined;
   additionalButtons?: ReactElement | null | undefined;
-  delete?: ButtonProps | null | undefined;
-  deleteText?: ReactNode | null | undefined;
+  cancel?: ButtonProps | null | undefined;
+  cancelText?: ReactNode | null | undefined;
 }
 
 function MantineQuestionnaireItemRenderer({

--- a/packages/mantine/src/r5/inputs/fhir-questionnaire.tsx
+++ b/packages/mantine/src/r5/inputs/fhir-questionnaire.tsx
@@ -121,24 +121,7 @@ export function MantineFhirQuestionnaire(
           <Button type="submit" {...props.rendererProps?.submit}>
             {props.rendererProps?.submitText || "Submit"}
           </Button>
-          {props.onDraft && (
-            <Button
-              variant="outline"
-              onClick={props.onDraft}
-              {...props.rendererProps?.draft}
-            >
-              {props.rendererProps?.draftText || "Save as draft"}
-            </Button>
-          )}
-          {props.onDelete && (
-            <Button
-              color="red"
-              onClick={props.onDelete}
-              {...props.rendererProps?.delete}
-            >
-              {props.rendererProps?.deleteText || "Delete"}
-            </Button>
-          )}
+          {props.additionalButtons && props.additionalButtons}
           {props.onCancel && (
             <Button
               variant="outline"
@@ -164,10 +147,7 @@ export interface MantineFhirQuestionnaireProps {
   itemInput?: FhirInputProps | null | undefined;
   submit?: ButtonProps | null | undefined;
   submitText?: ReactNode | null | undefined;
-  cancel?: ButtonProps | null | undefined;
-  cancelText?: ReactNode | null | undefined;
-  draft?: ButtonProps | null | undefined;
-  draftText?: ReactNode | null | undefined;
+  additionalButtons?: ReactElement | null | undefined;
   delete?: ButtonProps | null | undefined;
   deleteText?: ReactNode | null | undefined;
 }

--- a/packages/mantine/src/r5/inputs/fhir-questionnaire.tsx
+++ b/packages/mantine/src/r5/inputs/fhir-questionnaire.tsx
@@ -121,6 +121,24 @@ export function MantineFhirQuestionnaire(
           <Button type="submit" {...props.rendererProps?.submit}>
             {props.rendererProps?.submitText || "Submit"}
           </Button>
+          {props.onDraft && (
+            <Button
+              variant="outline"
+              onClick={props.onDraft}
+              {...props.rendererProps?.draft}
+            >
+              {props.rendererProps?.draftText || "Save as draft"}
+            </Button>
+          )}
+          {props.onDelete && (
+            <Button
+              color="red"
+              onClick={props.onDelete}
+              {...props.rendererProps?.delete}
+            >
+              {props.rendererProps?.deleteText || "Delete"}
+            </Button>
+          )}
           {props.onCancel && (
             <Button
               variant="outline"
@@ -148,6 +166,10 @@ export interface MantineFhirQuestionnaireProps {
   submitText?: ReactNode | null | undefined;
   cancel?: ButtonProps | null | undefined;
   cancelText?: ReactNode | null | undefined;
+  draft?: ButtonProps | null | undefined;
+  draftText?: ReactNode | null | undefined;
+  delete?: ButtonProps | null | undefined;
+  deleteText?: ReactNode | null | undefined;
 }
 
 function MantineQuestionnaireItemRenderer({

--- a/packages/mantine/src/r5/inputs/fhir-questionnaire.tsx
+++ b/packages/mantine/src/r5/inputs/fhir-questionnaire.tsx
@@ -148,8 +148,8 @@ export interface MantineFhirQuestionnaireProps {
   submit?: ButtonProps | null | undefined;
   submitText?: ReactNode | null | undefined;
   additionalButtons?: ReactElement | null | undefined;
-  delete?: ButtonProps | null | undefined;
-  deleteText?: ReactNode | null | undefined;
+  cancel?: ButtonProps | null | undefined;
+  cancelText?: ReactNode | null | undefined;
 }
 
 function MantineQuestionnaireItemRenderer({

--- a/packages/react/src/r4b/inputs/fhir-questionnaire.tsx
+++ b/packages/react/src/r4b/inputs/fhir-questionnaire.tsx
@@ -7,7 +7,7 @@ import {
 } from "@bonfhir/core/r4b";
 import { useFhirSearchOne } from "@bonfhir/query/r4b";
 import { UseQueryResult } from "@tanstack/react-query";
-import { ReactElement } from "react";
+import { MouseEventHandler, ReactElement } from "react";
 import { useFhirUIContext } from "../context";
 
 export interface FhirQuestionnaireProps<TRendererProps = any> {
@@ -26,6 +26,8 @@ export interface FhirQuestionnaireProps<TRendererProps = any> {
     | undefined;
   onSubmit?: ((value: QuestionnaireResponse) => void) | null | undefined;
   onCancel?: (() => void) | null | undefined;
+  onDraft?: MouseEventHandler<HTMLButtonElement>;
+  onDelete?: MouseEventHandler<HTMLButtonElement>;
   rendererProps?: TRendererProps;
 }
 

--- a/packages/react/src/r4b/inputs/fhir-questionnaire.tsx
+++ b/packages/react/src/r4b/inputs/fhir-questionnaire.tsx
@@ -7,7 +7,7 @@ import {
 } from "@bonfhir/core/r4b";
 import { useFhirSearchOne } from "@bonfhir/query/r4b";
 import { UseQueryResult } from "@tanstack/react-query";
-import { MouseEventHandler, ReactElement } from "react";
+import { ReactElement } from "react";
 import { useFhirUIContext } from "../context";
 
 export interface FhirQuestionnaireProps<TRendererProps = any> {
@@ -26,8 +26,7 @@ export interface FhirQuestionnaireProps<TRendererProps = any> {
     | undefined;
   onSubmit?: ((value: QuestionnaireResponse) => void) | null | undefined;
   onCancel?: (() => void) | null | undefined;
-  onDraft?: MouseEventHandler<HTMLButtonElement>;
-  onDelete?: MouseEventHandler<HTMLButtonElement>;
+  additionalButtons?: ReactElement | null | undefined;
   rendererProps?: TRendererProps;
 }
 

--- a/packages/react/src/r5/inputs/fhir-questionnaire.tsx
+++ b/packages/react/src/r5/inputs/fhir-questionnaire.tsx
@@ -7,7 +7,7 @@ import {
 } from "@bonfhir/core/r5";
 import { useFhirSearchOne } from "@bonfhir/query/r5";
 import { UseQueryResult } from "@tanstack/react-query";
-import { ReactElement } from "react";
+import { MouseEventHandler, ReactElement } from "react";
 import { useFhirUIContext } from "../context";
 
 export interface FhirQuestionnaireProps<TRendererProps = any> {
@@ -26,6 +26,8 @@ export interface FhirQuestionnaireProps<TRendererProps = any> {
     | undefined;
   onSubmit?: ((value: QuestionnaireResponse) => void) | null | undefined;
   onCancel?: (() => void) | null | undefined;
+  onDraft?: MouseEventHandler<HTMLButtonElement>;
+  onDelete?: MouseEventHandler<HTMLButtonElement>;
   rendererProps?: TRendererProps;
 }
 

--- a/packages/react/src/r5/inputs/fhir-questionnaire.tsx
+++ b/packages/react/src/r5/inputs/fhir-questionnaire.tsx
@@ -7,7 +7,7 @@ import {
 } from "@bonfhir/core/r5";
 import { useFhirSearchOne } from "@bonfhir/query/r5";
 import { UseQueryResult } from "@tanstack/react-query";
-import { MouseEventHandler, ReactElement } from "react";
+import { ReactElement } from "react";
 import { useFhirUIContext } from "../context";
 
 export interface FhirQuestionnaireProps<TRendererProps = any> {
@@ -26,8 +26,7 @@ export interface FhirQuestionnaireProps<TRendererProps = any> {
     | undefined;
   onSubmit?: ((value: QuestionnaireResponse) => void) | null | undefined;
   onCancel?: (() => void) | null | undefined;
-  onDraft?: MouseEventHandler<HTMLButtonElement>;
-  onDelete?: MouseEventHandler<HTMLButtonElement>;
+  additionalButtons?: ReactElement | null | undefined;
   rendererProps?: TRendererProps;
 }
 


### PR DESCRIPTION
This PR adds the option to add `save as draft` and `delete` buttons to the questionnaire, with the user able to pass the actions and text down as props in the same pattern as the submit & cancel buttons