### PR TITLE
Add `className` and `style` props to all react components

### DIFF
--- a/.changeset/little-lemons-obey.md
+++ b/.changeset/little-lemons-obey.md
@@ -1,0 +1,6 @@
+---
+"@bonfhir/mantine": minor
+"@bonfhir/react": minor
+---
+
+Fix #81: add `className` to all react components

--- a/.changeset/tidy-panthers-decide.md
+++ b/.changeset/tidy-panthers-decide.md
@@ -1,0 +1,6 @@
+---
+"@bonfhir/mantine": minor
+"@bonfhir/react": minor
+---
+
+Fix #81: add `style` to all react components

--- a/packages/mantine/src/r4b/data-display/fhir-table.tsx
+++ b/packages/mantine/src/r4b/data-display/fhir-table.tsx
@@ -24,7 +24,11 @@ export function MantineFhirTable(
   const { onNavigate } = useFhirUIContext();
 
   return (
-    <Table className={props.className} {...props.rendererProps?.table}>
+    <Table
+      className={props.className}
+      style={props.style}
+      {...props.rendererProps?.table}
+    >
       <thead {...props.rendererProps?.thead}>
         {props.rendererProps?.theadPrefix
           ? createElement(props.rendererProps.theadPrefix)

--- a/packages/mantine/src/r4b/data-display/fhir-table.tsx
+++ b/packages/mantine/src/r4b/data-display/fhir-table.tsx
@@ -24,7 +24,7 @@ export function MantineFhirTable(
   const { onNavigate } = useFhirUIContext();
 
   return (
-    <Table {...props.rendererProps?.table}>
+    <Table className={props.className} {...props.rendererProps?.table}>
       <thead {...props.rendererProps?.thead}>
         {props.rendererProps?.theadPrefix
           ? createElement(props.rendererProps.theadPrefix)

--- a/packages/mantine/src/r4b/data-display/fhir-value.tsx
+++ b/packages/mantine/src/r4b/data-display/fhir-value.tsx
@@ -21,7 +21,7 @@ export function MantineFhirValue(
     return (
       <HoverCard openDelay={1000} {...props.rendererProps?.hoverCard}>
         <HoverCard.Target {...props.rendererProps?.hoverCardTarget}>
-          <Text span {...props.rendererProps?.text}>
+          <Text span className={props.className} {...props.rendererProps?.text}>
             {props.formattedValue}
           </Text>
         </HoverCard.Target>
@@ -41,6 +41,7 @@ export function MantineFhirValue(
   if (props.type === "markdown" && props.options?.style === "html") {
     return (
       <Text
+        className={props.className}
         component="div"
         dangerouslySetInnerHTML={{
           __html: props.formattedValue,
@@ -51,7 +52,7 @@ export function MantineFhirValue(
   }
 
   return (
-    <Text span {...props.rendererProps?.text}>
+    <Text span className={props.className} {...props.rendererProps?.text}>
       {props.formattedValue}
     </Text>
   );

--- a/packages/mantine/src/r4b/data-display/fhir-value.tsx
+++ b/packages/mantine/src/r4b/data-display/fhir-value.tsx
@@ -21,7 +21,12 @@ export function MantineFhirValue(
     return (
       <HoverCard openDelay={1000} {...props.rendererProps?.hoverCard}>
         <HoverCard.Target {...props.rendererProps?.hoverCardTarget}>
-          <Text span className={props.className} {...props.rendererProps?.text}>
+          <Text
+            span
+            className={props.className}
+            style={props.style}
+            {...props.rendererProps?.text}
+          >
             {props.formattedValue}
           </Text>
         </HoverCard.Target>
@@ -42,6 +47,7 @@ export function MantineFhirValue(
     return (
       <Text
         className={props.className}
+        style={props.style}
         component="div"
         dangerouslySetInnerHTML={{
           __html: props.formattedValue,
@@ -52,7 +58,12 @@ export function MantineFhirValue(
   }
 
   return (
-    <Text span className={props.className} {...props.rendererProps?.text}>
+    <Text
+      span
+      className={props.className}
+      style={props.style}
+      {...props.rendererProps?.text}
+    >
       {props.formattedValue}
     </Text>
   );

--- a/packages/mantine/src/r4b/feedback/fhir-error.tsx
+++ b/packages/mantine/src/r4b/feedback/fhir-error.tsx
@@ -19,6 +19,7 @@ export function MantineFhirError(
   return (
     <Alert
       className={props.className}
+      style={props.style}
       icon={<IconAlertCircle size="1rem" />}
       title={props.rendererProps?.titleText ?? "Something went wrong."}
       color="red"

--- a/packages/mantine/src/r4b/feedback/fhir-error.tsx
+++ b/packages/mantine/src/r4b/feedback/fhir-error.tsx
@@ -18,6 +18,7 @@ export function MantineFhirError(
 
   return (
     <Alert
+      className={props.className}
       icon={<IconAlertCircle size="1rem" />}
       title={props.rendererProps?.titleText ?? "Something went wrong."}
       color="red"

--- a/packages/mantine/src/r4b/feedback/fhir-query-loader.tsx
+++ b/packages/mantine/src/r4b/feedback/fhir-query-loader.tsx
@@ -18,7 +18,11 @@ export function MantineFhirQueryLoader(
 ): ReactElement | null {
   if (props.isLoading) {
     return (
-      <Stack className={props.className} {...props.rendererProps?.stack}>
+      <Stack
+        className={props.className}
+        style={props.style}
+        {...props.rendererProps?.stack}
+      >
         {props.loader || (
           <Center {...props.rendererProps?.center}>
             <Loader {...props.rendererProps?.loader} />
@@ -31,7 +35,11 @@ export function MantineFhirQueryLoader(
   if (props.isError) {
     console.error(props.errors);
     return (
-      <Stack className={props.className} {...props.rendererProps?.stack}>
+      <Stack
+        className={props.className}
+        style={props.style}
+        {...props.rendererProps?.stack}
+      >
         {props.errors.map((error, index) =>
           props.error ? (
             props.error(error)
@@ -53,7 +61,11 @@ export function MantineFhirQueryLoader(
   }
 
   return (
-    <Stack className={props.className} {...props.rendererProps?.stack}>
+    <Stack
+      className={props.className}
+      style={props.style}
+      {...props.rendererProps?.stack}
+    >
       {props.children}
     </Stack>
   );

--- a/packages/mantine/src/r4b/feedback/fhir-query-loader.tsx
+++ b/packages/mantine/src/r4b/feedback/fhir-query-loader.tsx
@@ -18,7 +18,7 @@ export function MantineFhirQueryLoader(
 ): ReactElement | null {
   if (props.isLoading) {
     return (
-      <Stack {...props.rendererProps?.stack}>
+      <Stack className={props.className} {...props.rendererProps?.stack}>
         {props.loader || (
           <Center {...props.rendererProps?.center}>
             <Loader {...props.rendererProps?.loader} />
@@ -31,7 +31,7 @@ export function MantineFhirQueryLoader(
   if (props.isError) {
     console.error(props.errors);
     return (
-      <Stack {...props.rendererProps?.stack}>
+      <Stack className={props.className} {...props.rendererProps?.stack}>
         {props.errors.map((error, index) =>
           props.error ? (
             props.error(error)
@@ -52,7 +52,11 @@ export function MantineFhirQueryLoader(
     );
   }
 
-  return <Stack {...props.rendererProps?.stack}>{props.children}</Stack>;
+  return (
+    <Stack className={props.className} {...props.rendererProps?.stack}>
+      {props.children}
+    </Stack>
+  );
 }
 
 export interface MantineFhirQueryLoaderProps {

--- a/packages/mantine/src/r4b/inputs/fhir-input-array.tsx
+++ b/packages/mantine/src/r4b/inputs/fhir-input-array.tsx
@@ -27,6 +27,7 @@ export function MantineFhirInputArray(
 
   return (
     <Input.Wrapper
+      className={props.className}
       label={props.label}
       description={props.description}
       error={props.error}

--- a/packages/mantine/src/r4b/inputs/fhir-input-array.tsx
+++ b/packages/mantine/src/r4b/inputs/fhir-input-array.tsx
@@ -28,6 +28,7 @@ export function MantineFhirInputArray(
   return (
     <Input.Wrapper
       className={props.className}
+      style={props.style}
       label={props.label}
       description={props.description}
       error={props.error}

--- a/packages/mantine/src/r4b/inputs/fhir-questionnaire.tsx
+++ b/packages/mantine/src/r4b/inputs/fhir-questionnaire.tsx
@@ -74,6 +74,7 @@ export function MantineFhirQuestionnaire(
     return (
       <Stack
         className={props.className}
+        style={props.style}
         align="center"
         {...props.rendererProps?.mainStack}
       >
@@ -85,7 +86,11 @@ export function MantineFhirQuestionnaire(
   if (props.errors.length > 0) {
     console.error(props.errors);
     return (
-      <Stack className={props.className} {...props.rendererProps?.mainStack}>
+      <Stack
+        className={props.className}
+        style={props.style}
+        {...props.rendererProps?.mainStack}
+      >
         {props.errors.map((error, index) => (
           <Alert
             key={index}
@@ -106,7 +111,11 @@ export function MantineFhirQuestionnaire(
         (questionnaireResponse) => props.onSubmit?.(questionnaireResponse),
       )}
     >
-      <Stack className={props.className} {...props.rendererProps?.mainStack}>
+      <Stack
+        className={props.className}
+        style={props.style}
+        {...props.rendererProps?.mainStack}
+      >
         {props.questionnaire!.title && (
           <Title order={2} {...props.rendererProps?.title}>
             {props.questionnaire!.title}

--- a/packages/mantine/src/r4b/inputs/fhir-questionnaire.tsx
+++ b/packages/mantine/src/r4b/inputs/fhir-questionnaire.tsx
@@ -72,7 +72,11 @@ export function MantineFhirQuestionnaire(
 
   if (props.isLoading || !props.questionnaire) {
     return (
-      <Stack align="center" {...props.rendererProps?.mainStack}>
+      <Stack
+        className={props.className}
+        align="center"
+        {...props.rendererProps?.mainStack}
+      >
         <Loader {...props.rendererProps?.loader} />
       </Stack>
     );
@@ -81,7 +85,7 @@ export function MantineFhirQuestionnaire(
   if (props.errors.length > 0) {
     console.error(props.errors);
     return (
-      <Stack {...props.rendererProps?.mainStack}>
+      <Stack className={props.className} {...props.rendererProps?.mainStack}>
         {props.errors.map((error, index) => (
           <Alert
             key={index}
@@ -102,7 +106,7 @@ export function MantineFhirQuestionnaire(
         (questionnaireResponse) => props.onSubmit?.(questionnaireResponse),
       )}
     >
-      <Stack {...props.rendererProps?.mainStack}>
+      <Stack className={props.className} {...props.rendererProps?.mainStack}>
         {props.questionnaire!.title && (
           <Title order={2} {...props.rendererProps?.title}>
             {props.questionnaire!.title}

--- a/packages/mantine/src/r4b/inputs/input-types/fhir-input-boolean.tsx
+++ b/packages/mantine/src/r4b/inputs/input-types/fhir-input-boolean.tsx
@@ -8,6 +8,7 @@ export function MantineFhirInputBoolean(
   if (!props.mode || props.mode === "checkbox") {
     return (
       <Checkbox
+        className={props.className}
         label={props.label}
         description={props.description}
         error={props.error}
@@ -25,6 +26,7 @@ export function MantineFhirInputBoolean(
   if (props.mode === "switch") {
     return (
       <Switch
+        className={props.className}
         label={props.label}
         description={props.description}
         error={props.error}

--- a/packages/mantine/src/r4b/inputs/input-types/fhir-input-boolean.tsx
+++ b/packages/mantine/src/r4b/inputs/input-types/fhir-input-boolean.tsx
@@ -9,6 +9,7 @@ export function MantineFhirInputBoolean(
     return (
       <Checkbox
         className={props.className}
+        style={props.style}
         label={props.label}
         description={props.description}
         error={props.error}
@@ -27,6 +28,7 @@ export function MantineFhirInputBoolean(
     return (
       <Switch
         className={props.className}
+        style={props.style}
         label={props.label}
         description={props.description}
         error={props.error}

--- a/packages/mantine/src/r4b/inputs/input-types/fhir-input-contact-point.tsx
+++ b/packages/mantine/src/r4b/inputs/input-types/fhir-input-contact-point.tsx
@@ -37,6 +37,7 @@ export function MantineFhirInputContactPoint(
   return (
     <Input.Wrapper
       className={props.className}
+      style={props.style}
       label={props.label}
       description={props.description}
       error={props.error}

--- a/packages/mantine/src/r4b/inputs/input-types/fhir-input-contact-point.tsx
+++ b/packages/mantine/src/r4b/inputs/input-types/fhir-input-contact-point.tsx
@@ -36,6 +36,7 @@ export function MantineFhirInputContactPoint(
 
   return (
     <Input.Wrapper
+      className={props.className}
       label={props.label}
       description={props.description}
       error={props.error}

--- a/packages/mantine/src/r4b/inputs/input-types/fhir-input-date-time.tsx
+++ b/packages/mantine/src/r4b/inputs/input-types/fhir-input-date-time.tsx
@@ -8,6 +8,7 @@ export function MantineFhirInputDateTime(
   return (
     <DateTimePicker
       className={props.className}
+      style={props.style}
       label={props.label}
       description={props.description}
       error={props.error}

--- a/packages/mantine/src/r4b/inputs/input-types/fhir-input-date-time.tsx
+++ b/packages/mantine/src/r4b/inputs/input-types/fhir-input-date-time.tsx
@@ -7,6 +7,7 @@ export function MantineFhirInputDateTime(
 ): ReactElement | null {
   return (
     <DateTimePicker
+      className={props.className}
       label={props.label}
       description={props.description}
       error={props.error}

--- a/packages/mantine/src/r4b/inputs/input-types/fhir-input-date.tsx
+++ b/packages/mantine/src/r4b/inputs/input-types/fhir-input-date.tsx
@@ -29,6 +29,7 @@ export function MantineFhirInputDate(
 
   return (
     <DateInput
+      className={props.className}
       label={props.label}
       description={props.description}
       error={props.error}

--- a/packages/mantine/src/r4b/inputs/input-types/fhir-input-date.tsx
+++ b/packages/mantine/src/r4b/inputs/input-types/fhir-input-date.tsx
@@ -30,6 +30,7 @@ export function MantineFhirInputDate(
   return (
     <DateInput
       className={props.className}
+      style={props.style}
       label={props.label}
       description={props.description}
       error={props.error}

--- a/packages/mantine/src/r4b/inputs/input-types/fhir-input-human-name.tsx
+++ b/packages/mantine/src/r4b/inputs/input-types/fhir-input-human-name.tsx
@@ -28,6 +28,7 @@ export function MantineFhirInputHumanName(
   return (
     <Input.Wrapper
       className={props.className}
+      style={props.style}
       label={props.label}
       description={props.description}
       error={props.error}

--- a/packages/mantine/src/r4b/inputs/input-types/fhir-input-human-name.tsx
+++ b/packages/mantine/src/r4b/inputs/input-types/fhir-input-human-name.tsx
@@ -27,6 +27,7 @@ export function MantineFhirInputHumanName(
 
   return (
     <Input.Wrapper
+      className={props.className}
       label={props.label}
       description={props.description}
       error={props.error}

--- a/packages/mantine/src/r4b/inputs/input-types/fhir-input-identifier.tsx
+++ b/packages/mantine/src/r4b/inputs/input-types/fhir-input-identifier.tsx
@@ -43,6 +43,7 @@ export function MantineFhirInputIdentifier(
 
   return (
     <Input.Wrapper
+      className={props.className}
       label={props.label}
       description={props.description}
       error={props.error}

--- a/packages/mantine/src/r4b/inputs/input-types/fhir-input-identifier.tsx
+++ b/packages/mantine/src/r4b/inputs/input-types/fhir-input-identifier.tsx
@@ -44,6 +44,7 @@ export function MantineFhirInputIdentifier(
   return (
     <Input.Wrapper
       className={props.className}
+      style={props.style}
       label={props.label}
       description={props.description}
       error={props.error}

--- a/packages/mantine/src/r4b/inputs/input-types/fhir-input-markdown.tsx
+++ b/packages/mantine/src/r4b/inputs/input-types/fhir-input-markdown.tsx
@@ -43,6 +43,7 @@ export function MantineFhirInputMarkdown(
   return (
     <Input.Wrapper
       className={props.className}
+      style={props.style}
       label={props.label}
       description={props.description}
       error={props.error}

--- a/packages/mantine/src/r4b/inputs/input-types/fhir-input-markdown.tsx
+++ b/packages/mantine/src/r4b/inputs/input-types/fhir-input-markdown.tsx
@@ -42,6 +42,7 @@ export function MantineFhirInputMarkdown(
 
   return (
     <Input.Wrapper
+      className={props.className}
       label={props.label}
       description={props.description}
       error={props.error}

--- a/packages/mantine/src/r4b/inputs/input-types/fhir-input-number.tsx
+++ b/packages/mantine/src/r4b/inputs/input-types/fhir-input-number.tsx
@@ -7,6 +7,7 @@ export function MantineFhirInputNumber(
 ): ReactElement | null {
   return (
     <NumberInput
+      className={props.className}
       label={props.label}
       description={props.description}
       error={props.error}

--- a/packages/mantine/src/r4b/inputs/input-types/fhir-input-number.tsx
+++ b/packages/mantine/src/r4b/inputs/input-types/fhir-input-number.tsx
@@ -8,6 +8,7 @@ export function MantineFhirInputNumber(
   return (
     <NumberInput
       className={props.className}
+      style={props.style}
       label={props.label}
       description={props.description}
       error={props.error}

--- a/packages/mantine/src/r4b/inputs/input-types/fhir-input-resource.tsx
+++ b/packages/mantine/src/r4b/inputs/input-types/fhir-input-resource.tsx
@@ -16,6 +16,7 @@ export function MantineFhirInputResource(
 
   return (
     <Select
+      className={props.className}
       label={props.label}
       description={props.description}
       error={props.error}

--- a/packages/mantine/src/r4b/inputs/input-types/fhir-input-resource.tsx
+++ b/packages/mantine/src/r4b/inputs/input-types/fhir-input-resource.tsx
@@ -17,6 +17,7 @@ export function MantineFhirInputResource(
   return (
     <Select
       className={props.className}
+      style={props.style}
       label={props.label}
       description={props.description}
       error={props.error}

--- a/packages/mantine/src/r4b/inputs/input-types/fhir-input-string.tsx
+++ b/packages/mantine/src/r4b/inputs/input-types/fhir-input-string.tsx
@@ -15,6 +15,7 @@ export function MantineFhirInputString(
     return (
       <Textarea
         className={props.className}
+        style={props.style}
         label={props.label}
         description={props.description}
         error={props.error}
@@ -36,6 +37,7 @@ export function MantineFhirInputString(
   return (
     <TextInput
       className={props.className}
+      style={props.style}
       label={props.label}
       description={props.description}
       error={props.error}

--- a/packages/mantine/src/r4b/inputs/input-types/fhir-input-string.tsx
+++ b/packages/mantine/src/r4b/inputs/input-types/fhir-input-string.tsx
@@ -14,6 +14,7 @@ export function MantineFhirInputString(
   if (props.type === "string" && props.mode === "multiline") {
     return (
       <Textarea
+        className={props.className}
         label={props.label}
         description={props.description}
         error={props.error}
@@ -34,6 +35,7 @@ export function MantineFhirInputString(
   }
   return (
     <TextInput
+      className={props.className}
       label={props.label}
       description={props.description}
       error={props.error}

--- a/packages/mantine/src/r4b/inputs/input-types/fhir-input-terminology.tsx
+++ b/packages/mantine/src/r4b/inputs/input-types/fhir-input-terminology.tsx
@@ -81,6 +81,7 @@ export function MantineFhirInputTerminology(
       // @ts-expect-error
       <Select
         className={props.className}
+        style={props.style}
         label={props.label}
         description={props.description}
         error={props.error}
@@ -110,6 +111,7 @@ export function MantineFhirInputTerminology(
       // @ts-expect-error
       <Radio.Group
         className={props.className}
+        style={props.style}
         label={props.label}
         description={props.description}
         error={props.error}
@@ -136,6 +138,7 @@ export function MantineFhirInputTerminology(
     return (
       <Input.Wrapper
         className={props.className}
+        style={props.style}
         label={props.label}
         description={props.description}
         error={props.error}

--- a/packages/mantine/src/r4b/inputs/input-types/fhir-input-terminology.tsx
+++ b/packages/mantine/src/r4b/inputs/input-types/fhir-input-terminology.tsx
@@ -80,6 +80,7 @@ export function MantineFhirInputTerminology(
       // eslint-disable-next-line @typescript-eslint/ban-ts-comment
       // @ts-expect-error
       <Select
+        className={props.className}
         label={props.label}
         description={props.description}
         error={props.error}
@@ -108,6 +109,7 @@ export function MantineFhirInputTerminology(
       // eslint-disable-next-line @typescript-eslint/ban-ts-comment
       // @ts-expect-error
       <Radio.Group
+        className={props.className}
         label={props.label}
         description={props.description}
         error={props.error}
@@ -133,6 +135,7 @@ export function MantineFhirInputTerminology(
   if (props.mode === "segmented") {
     return (
       <Input.Wrapper
+        className={props.className}
         label={props.label}
         description={props.description}
         error={props.error}

--- a/packages/mantine/src/r4b/inputs/input-types/fhir-input-time.tsx
+++ b/packages/mantine/src/r4b/inputs/input-types/fhir-input-time.tsx
@@ -7,6 +7,7 @@ export function MantineFhirInputTime(
 ): ReactElement | null {
   return (
     <TimeInput
+      className={props.className}
       label={props.label}
       description={props.description}
       error={props.error}

--- a/packages/mantine/src/r4b/inputs/input-types/fhir-input-time.tsx
+++ b/packages/mantine/src/r4b/inputs/input-types/fhir-input-time.tsx
@@ -8,6 +8,7 @@ export function MantineFhirInputTime(
   return (
     <TimeInput
       className={props.className}
+      style={props.style}
       label={props.label}
       description={props.description}
       error={props.error}

--- a/packages/mantine/src/r4b/navigation/fhir-pagination.tsx
+++ b/packages/mantine/src/r4b/navigation/fhir-pagination.tsx
@@ -15,6 +15,9 @@ export function MantineFhirPagination(
       classNames={{
         control: props.className,
       }}
+      styles={{
+        control: props.style,
+      }}
       total={props.totalPages}
       value={props.pageNumber}
       disabled={props.totalPages === 0}

--- a/packages/mantine/src/r4b/navigation/fhir-pagination.tsx
+++ b/packages/mantine/src/r4b/navigation/fhir-pagination.tsx
@@ -12,6 +12,9 @@ export function MantineFhirPagination(
 ): ReactElement | null {
   return (
     <Pagination.Root
+      classNames={{
+        control: props.className,
+      }}
       total={props.totalPages}
       value={props.pageNumber}
       disabled={props.totalPages === 0}

--- a/packages/mantine/src/r5/data-display/fhir-table.tsx
+++ b/packages/mantine/src/r5/data-display/fhir-table.tsx
@@ -24,7 +24,11 @@ export function MantineFhirTable(
   const { onNavigate } = useFhirUIContext();
 
   return (
-    <Table className={props.className} {...props.rendererProps?.table}>
+    <Table
+      className={props.className}
+      style={props.style}
+      {...props.rendererProps?.table}
+    >
       <thead {...props.rendererProps?.thead}>
         {props.rendererProps?.theadPrefix
           ? createElement(props.rendererProps.theadPrefix)

--- a/packages/mantine/src/r5/data-display/fhir-table.tsx
+++ b/packages/mantine/src/r5/data-display/fhir-table.tsx
@@ -24,7 +24,7 @@ export function MantineFhirTable(
   const { onNavigate } = useFhirUIContext();
 
   return (
-    <Table {...props.rendererProps?.table}>
+    <Table className={props.className} {...props.rendererProps?.table}>
       <thead {...props.rendererProps?.thead}>
         {props.rendererProps?.theadPrefix
           ? createElement(props.rendererProps.theadPrefix)

--- a/packages/mantine/src/r5/data-display/fhir-value.tsx
+++ b/packages/mantine/src/r5/data-display/fhir-value.tsx
@@ -18,7 +18,12 @@ export function MantineFhirValue(
     return (
       <HoverCard openDelay={1000} {...props.rendererProps?.hoverCard}>
         <HoverCard.Target {...props.rendererProps?.hoverCardTarget}>
-          <Text span className={props.className} {...props.rendererProps?.text}>
+          <Text
+            span
+            className={props.className}
+            style={props.style}
+            {...props.rendererProps?.text}
+          >
             {props.formattedValue}
           </Text>
         </HoverCard.Target>
@@ -39,6 +44,7 @@ export function MantineFhirValue(
     return (
       <Text
         className={props.className}
+        style={props.style}
         component="div"
         dangerouslySetInnerHTML={{
           __html: props.formattedValue,
@@ -49,7 +55,12 @@ export function MantineFhirValue(
   }
 
   return (
-    <Text span className={props.className} {...props.rendererProps?.text}>
+    <Text
+      span
+      className={props.className}
+      style={props.style}
+      {...props.rendererProps?.text}
+    >
       {props.formattedValue}
     </Text>
   );

--- a/packages/mantine/src/r5/data-display/fhir-value.tsx
+++ b/packages/mantine/src/r5/data-display/fhir-value.tsx
@@ -18,7 +18,7 @@ export function MantineFhirValue(
     return (
       <HoverCard openDelay={1000} {...props.rendererProps?.hoverCard}>
         <HoverCard.Target {...props.rendererProps?.hoverCardTarget}>
-          <Text span {...props.rendererProps?.text}>
+          <Text span className={props.className} {...props.rendererProps?.text}>
             {props.formattedValue}
           </Text>
         </HoverCard.Target>
@@ -38,6 +38,7 @@ export function MantineFhirValue(
   if (props.type === "markdown" && props.options?.style === "html") {
     return (
       <Text
+        className={props.className}
         component="div"
         dangerouslySetInnerHTML={{
           __html: props.formattedValue,
@@ -48,7 +49,7 @@ export function MantineFhirValue(
   }
 
   return (
-    <Text span {...props.rendererProps?.text}>
+    <Text span className={props.className} {...props.rendererProps?.text}>
       {props.formattedValue}
     </Text>
   );

--- a/packages/mantine/src/r5/feedback/fhir-error.tsx
+++ b/packages/mantine/src/r5/feedback/fhir-error.tsx
@@ -19,6 +19,7 @@ export function MantineFhirError(
   return (
     <Alert
       className={props.className}
+      style={props.style}
       icon={<IconAlertCircle size="1rem" />}
       title={props.rendererProps?.titleText ?? "Something went wrong."}
       color="red"

--- a/packages/mantine/src/r5/feedback/fhir-error.tsx
+++ b/packages/mantine/src/r5/feedback/fhir-error.tsx
@@ -18,6 +18,7 @@ export function MantineFhirError(
 
   return (
     <Alert
+      className={props.className}
       icon={<IconAlertCircle size="1rem" />}
       title={props.rendererProps?.titleText ?? "Something went wrong."}
       color="red"

--- a/packages/mantine/src/r5/feedback/fhir-query-loader.tsx
+++ b/packages/mantine/src/r5/feedback/fhir-query-loader.tsx
@@ -18,7 +18,11 @@ export function MantineFhirQueryLoader(
 ): ReactElement | null {
   if (props.isLoading) {
     return (
-      <Stack className={props.className} {...props.rendererProps?.stack}>
+      <Stack
+        className={props.className}
+        style={props.style}
+        {...props.rendererProps?.stack}
+      >
         {props.loader || (
           <Center {...props.rendererProps?.center}>
             <Loader {...props.rendererProps?.loader} />
@@ -31,7 +35,11 @@ export function MantineFhirQueryLoader(
   if (props.isError) {
     console.error(props.errors);
     return (
-      <Stack className={props.className} {...props.rendererProps?.stack}>
+      <Stack
+        className={props.className}
+        style={props.style}
+        {...props.rendererProps?.stack}
+      >
         {props.errors.map((error, index) =>
           props.error ? (
             props.error(error)
@@ -53,7 +61,11 @@ export function MantineFhirQueryLoader(
   }
 
   return (
-    <Stack className={props.className} {...props.rendererProps?.stack}>
+    <Stack
+      className={props.className}
+      style={props.style}
+      {...props.rendererProps?.stack}
+    >
       {props.children}
     </Stack>
   );

--- a/packages/mantine/src/r5/feedback/fhir-query-loader.tsx
+++ b/packages/mantine/src/r5/feedback/fhir-query-loader.tsx
@@ -18,7 +18,7 @@ export function MantineFhirQueryLoader(
 ): ReactElement | null {
   if (props.isLoading) {
     return (
-      <Stack {...props.rendererProps?.stack}>
+      <Stack className={props.className} {...props.rendererProps?.stack}>
         {props.loader || (
           <Center {...props.rendererProps?.center}>
             <Loader {...props.rendererProps?.loader} />
@@ -31,7 +31,7 @@ export function MantineFhirQueryLoader(
   if (props.isError) {
     console.error(props.errors);
     return (
-      <Stack {...props.rendererProps?.stack}>
+      <Stack className={props.className} {...props.rendererProps?.stack}>
         {props.errors.map((error, index) =>
           props.error ? (
             props.error(error)
@@ -52,7 +52,11 @@ export function MantineFhirQueryLoader(
     );
   }
 
-  return <Stack {...props.rendererProps?.stack}>{props.children}</Stack>;
+  return (
+    <Stack className={props.className} {...props.rendererProps?.stack}>
+      {props.children}
+    </Stack>
+  );
 }
 
 export interface MantineFhirQueryLoaderProps {

--- a/packages/mantine/src/r5/inputs/fhir-input-array.tsx
+++ b/packages/mantine/src/r5/inputs/fhir-input-array.tsx
@@ -27,6 +27,7 @@ export function MantineFhirInputArray(
 
   return (
     <Input.Wrapper
+      className={props.className}
       label={props.label}
       description={props.description}
       error={props.error}

--- a/packages/mantine/src/r5/inputs/fhir-input-array.tsx
+++ b/packages/mantine/src/r5/inputs/fhir-input-array.tsx
@@ -28,6 +28,7 @@ export function MantineFhirInputArray(
   return (
     <Input.Wrapper
       className={props.className}
+      style={props.style}
       label={props.label}
       description={props.description}
       error={props.error}

--- a/packages/mantine/src/r5/inputs/fhir-questionnaire.tsx
+++ b/packages/mantine/src/r5/inputs/fhir-questionnaire.tsx
@@ -74,6 +74,7 @@ export function MantineFhirQuestionnaire(
     return (
       <Stack
         className={props.className}
+        style={props.style}
         align="center"
         {...props.rendererProps?.mainStack}
       >
@@ -85,7 +86,11 @@ export function MantineFhirQuestionnaire(
   if (props.errors.length > 0) {
     console.error(props.errors);
     return (
-      <Stack className={props.className} {...props.rendererProps?.mainStack}>
+      <Stack
+        className={props.className}
+        style={props.style}
+        {...props.rendererProps?.mainStack}
+      >
         {props.errors.map((error, index) => (
           <Alert
             key={index}
@@ -106,7 +111,11 @@ export function MantineFhirQuestionnaire(
         (questionnaireResponse) => props.onSubmit?.(questionnaireResponse),
       )}
     >
-      <Stack className={props.className} {...props.rendererProps?.mainStack}>
+      <Stack
+        className={props.className}
+        style={props.style}
+        {...props.rendererProps?.mainStack}
+      >
         {props.questionnaire!.title && (
           <Title order={2} {...props.rendererProps?.title}>
             {props.questionnaire!.title}

--- a/packages/mantine/src/r5/inputs/fhir-questionnaire.tsx
+++ b/packages/mantine/src/r5/inputs/fhir-questionnaire.tsx
@@ -72,7 +72,11 @@ export function MantineFhirQuestionnaire(
 
   if (props.isLoading || !props.questionnaire) {
     return (
-      <Stack align="center" {...props.rendererProps?.mainStack}>
+      <Stack
+        className={props.className}
+        align="center"
+        {...props.rendererProps?.mainStack}
+      >
         <Loader {...props.rendererProps?.loader} />
       </Stack>
     );
@@ -81,7 +85,7 @@ export function MantineFhirQuestionnaire(
   if (props.errors.length > 0) {
     console.error(props.errors);
     return (
-      <Stack {...props.rendererProps?.mainStack}>
+      <Stack className={props.className} {...props.rendererProps?.mainStack}>
         {props.errors.map((error, index) => (
           <Alert
             key={index}
@@ -102,7 +106,7 @@ export function MantineFhirQuestionnaire(
         (questionnaireResponse) => props.onSubmit?.(questionnaireResponse),
       )}
     >
-      <Stack {...props.rendererProps?.mainStack}>
+      <Stack className={props.className} {...props.rendererProps?.mainStack}>
         {props.questionnaire!.title && (
           <Title order={2} {...props.rendererProps?.title}>
             {props.questionnaire!.title}

--- a/packages/mantine/src/r5/inputs/input-types/fhir-input-boolean.tsx
+++ b/packages/mantine/src/r5/inputs/input-types/fhir-input-boolean.tsx
@@ -8,6 +8,7 @@ export function MantineFhirInputBoolean(
   if (!props.mode || props.mode === "checkbox") {
     return (
       <Checkbox
+        className={props.className}
         label={props.label}
         description={props.description}
         error={props.error}
@@ -25,6 +26,7 @@ export function MantineFhirInputBoolean(
   if (props.mode === "switch") {
     return (
       <Switch
+        className={props.className}
         label={props.label}
         description={props.description}
         error={props.error}

--- a/packages/mantine/src/r5/inputs/input-types/fhir-input-boolean.tsx
+++ b/packages/mantine/src/r5/inputs/input-types/fhir-input-boolean.tsx
@@ -9,6 +9,7 @@ export function MantineFhirInputBoolean(
     return (
       <Checkbox
         className={props.className}
+        style={props.style}
         label={props.label}
         description={props.description}
         error={props.error}
@@ -27,6 +28,7 @@ export function MantineFhirInputBoolean(
     return (
       <Switch
         className={props.className}
+        style={props.style}
         label={props.label}
         description={props.description}
         error={props.error}

--- a/packages/mantine/src/r5/inputs/input-types/fhir-input-contact-point.tsx
+++ b/packages/mantine/src/r5/inputs/input-types/fhir-input-contact-point.tsx
@@ -37,6 +37,7 @@ export function MantineFhirInputContactPoint(
   return (
     <Input.Wrapper
       className={props.className}
+      style={props.style}
       label={props.label}
       description={props.description}
       error={props.error}

--- a/packages/mantine/src/r5/inputs/input-types/fhir-input-contact-point.tsx
+++ b/packages/mantine/src/r5/inputs/input-types/fhir-input-contact-point.tsx
@@ -36,6 +36,7 @@ export function MantineFhirInputContactPoint(
 
   return (
     <Input.Wrapper
+      className={props.className}
       label={props.label}
       description={props.description}
       error={props.error}

--- a/packages/mantine/src/r5/inputs/input-types/fhir-input-date-time.tsx
+++ b/packages/mantine/src/r5/inputs/input-types/fhir-input-date-time.tsx
@@ -8,6 +8,7 @@ export function MantineFhirInputDateTime(
   return (
     <DateTimePicker
       className={props.className}
+      style={props.style}
       label={props.label}
       description={props.description}
       error={props.error}

--- a/packages/mantine/src/r5/inputs/input-types/fhir-input-date-time.tsx
+++ b/packages/mantine/src/r5/inputs/input-types/fhir-input-date-time.tsx
@@ -7,6 +7,7 @@ export function MantineFhirInputDateTime(
 ): ReactElement | null {
   return (
     <DateTimePicker
+      className={props.className}
       label={props.label}
       description={props.description}
       error={props.error}

--- a/packages/mantine/src/r5/inputs/input-types/fhir-input-date.tsx
+++ b/packages/mantine/src/r5/inputs/input-types/fhir-input-date.tsx
@@ -29,6 +29,7 @@ export function MantineFhirInputDate(
 
   return (
     <DateInput
+      className={props.className}
       label={props.label}
       description={props.description}
       error={props.error}

--- a/packages/mantine/src/r5/inputs/input-types/fhir-input-date.tsx
+++ b/packages/mantine/src/r5/inputs/input-types/fhir-input-date.tsx
@@ -30,6 +30,7 @@ export function MantineFhirInputDate(
   return (
     <DateInput
       className={props.className}
+      style={props.style}
       label={props.label}
       description={props.description}
       error={props.error}

--- a/packages/mantine/src/r5/inputs/input-types/fhir-input-human-name.tsx
+++ b/packages/mantine/src/r5/inputs/input-types/fhir-input-human-name.tsx
@@ -28,6 +28,7 @@ export function MantineFhirInputHumanName(
   return (
     <Input.Wrapper
       className={props.className}
+      style={props.style}
       label={props.label}
       description={props.description}
       error={props.error}

--- a/packages/mantine/src/r5/inputs/input-types/fhir-input-human-name.tsx
+++ b/packages/mantine/src/r5/inputs/input-types/fhir-input-human-name.tsx
@@ -27,6 +27,7 @@ export function MantineFhirInputHumanName(
 
   return (
     <Input.Wrapper
+      className={props.className}
       label={props.label}
       description={props.description}
       error={props.error}

--- a/packages/mantine/src/r5/inputs/input-types/fhir-input-identifier.tsx
+++ b/packages/mantine/src/r5/inputs/input-types/fhir-input-identifier.tsx
@@ -43,6 +43,7 @@ export function MantineFhirInputIdentifier(
 
   return (
     <Input.Wrapper
+      className={props.className}
       label={props.label}
       description={props.description}
       error={props.error}

--- a/packages/mantine/src/r5/inputs/input-types/fhir-input-identifier.tsx
+++ b/packages/mantine/src/r5/inputs/input-types/fhir-input-identifier.tsx
@@ -44,6 +44,7 @@ export function MantineFhirInputIdentifier(
   return (
     <Input.Wrapper
       className={props.className}
+      style={props.style}
       label={props.label}
       description={props.description}
       error={props.error}

--- a/packages/mantine/src/r5/inputs/input-types/fhir-input-markdown.tsx
+++ b/packages/mantine/src/r5/inputs/input-types/fhir-input-markdown.tsx
@@ -43,6 +43,7 @@ export function MantineFhirInputMarkdown(
   return (
     <Input.Wrapper
       className={props.className}
+      style={props.style}
       label={props.label}
       description={props.description}
       error={props.error}

--- a/packages/mantine/src/r5/inputs/input-types/fhir-input-markdown.tsx
+++ b/packages/mantine/src/r5/inputs/input-types/fhir-input-markdown.tsx
@@ -42,6 +42,7 @@ export function MantineFhirInputMarkdown(
 
   return (
     <Input.Wrapper
+      className={props.className}
       label={props.label}
       description={props.description}
       error={props.error}

--- a/packages/mantine/src/r5/inputs/input-types/fhir-input-number.tsx
+++ b/packages/mantine/src/r5/inputs/input-types/fhir-input-number.tsx
@@ -7,6 +7,7 @@ export function MantineFhirInputNumber(
 ): ReactElement | null {
   return (
     <NumberInput
+      className={props.className}
       label={props.label}
       description={props.description}
       error={props.error}

--- a/packages/mantine/src/r5/inputs/input-types/fhir-input-number.tsx
+++ b/packages/mantine/src/r5/inputs/input-types/fhir-input-number.tsx
@@ -8,6 +8,7 @@ export function MantineFhirInputNumber(
   return (
     <NumberInput
       className={props.className}
+      style={props.style}
       label={props.label}
       description={props.description}
       error={props.error}

--- a/packages/mantine/src/r5/inputs/input-types/fhir-input-resource.tsx
+++ b/packages/mantine/src/r5/inputs/input-types/fhir-input-resource.tsx
@@ -16,6 +16,7 @@ export function MantineFhirInputResource(
 
   return (
     <Select
+      className={props.className}
       label={props.label}
       description={props.description}
       error={props.error}

--- a/packages/mantine/src/r5/inputs/input-types/fhir-input-resource.tsx
+++ b/packages/mantine/src/r5/inputs/input-types/fhir-input-resource.tsx
@@ -17,6 +17,7 @@ export function MantineFhirInputResource(
   return (
     <Select
       className={props.className}
+      style={props.style}
       label={props.label}
       description={props.description}
       error={props.error}

--- a/packages/mantine/src/r5/inputs/input-types/fhir-input-string.tsx
+++ b/packages/mantine/src/r5/inputs/input-types/fhir-input-string.tsx
@@ -15,6 +15,7 @@ export function MantineFhirInputString(
     return (
       <Textarea
         className={props.className}
+        style={props.style}
         label={props.label}
         description={props.description}
         error={props.error}
@@ -36,6 +37,7 @@ export function MantineFhirInputString(
   return (
     <TextInput
       className={props.className}
+      style={props.style}
       label={props.label}
       description={props.description}
       error={props.error}

--- a/packages/mantine/src/r5/inputs/input-types/fhir-input-string.tsx
+++ b/packages/mantine/src/r5/inputs/input-types/fhir-input-string.tsx
@@ -14,6 +14,7 @@ export function MantineFhirInputString(
   if (props.type === "string" && props.mode === "multiline") {
     return (
       <Textarea
+        className={props.className}
         label={props.label}
         description={props.description}
         error={props.error}
@@ -34,6 +35,7 @@ export function MantineFhirInputString(
   }
   return (
     <TextInput
+      className={props.className}
       label={props.label}
       description={props.description}
       error={props.error}

--- a/packages/mantine/src/r5/inputs/input-types/fhir-input-terminology.tsx
+++ b/packages/mantine/src/r5/inputs/input-types/fhir-input-terminology.tsx
@@ -81,6 +81,7 @@ export function MantineFhirInputTerminology(
       // @ts-expect-error
       <Select
         className={props.className}
+        style={props.style}
         label={props.label}
         description={props.description}
         error={props.error}
@@ -110,6 +111,7 @@ export function MantineFhirInputTerminology(
       // @ts-expect-error
       <Radio.Group
         className={props.className}
+        style={props.style}
         label={props.label}
         description={props.description}
         error={props.error}
@@ -136,6 +138,7 @@ export function MantineFhirInputTerminology(
     return (
       <Input.Wrapper
         className={props.className}
+        style={props.style}
         label={props.label}
         description={props.description}
         error={props.error}

--- a/packages/mantine/src/r5/inputs/input-types/fhir-input-terminology.tsx
+++ b/packages/mantine/src/r5/inputs/input-types/fhir-input-terminology.tsx
@@ -80,6 +80,7 @@ export function MantineFhirInputTerminology(
       // eslint-disable-next-line @typescript-eslint/ban-ts-comment
       // @ts-expect-error
       <Select
+        className={props.className}
         label={props.label}
         description={props.description}
         error={props.error}
@@ -108,6 +109,7 @@ export function MantineFhirInputTerminology(
       // eslint-disable-next-line @typescript-eslint/ban-ts-comment
       // @ts-expect-error
       <Radio.Group
+        className={props.className}
         label={props.label}
         description={props.description}
         error={props.error}
@@ -133,6 +135,7 @@ export function MantineFhirInputTerminology(
   if (props.mode === "segmented") {
     return (
       <Input.Wrapper
+        className={props.className}
         label={props.label}
         description={props.description}
         error={props.error}

--- a/packages/mantine/src/r5/inputs/input-types/fhir-input-time.tsx
+++ b/packages/mantine/src/r5/inputs/input-types/fhir-input-time.tsx
@@ -7,6 +7,7 @@ export function MantineFhirInputTime(
 ): ReactElement | null {
   return (
     <TimeInput
+      className={props.className}
       label={props.label}
       description={props.description}
       error={props.error}

--- a/packages/mantine/src/r5/inputs/input-types/fhir-input-time.tsx
+++ b/packages/mantine/src/r5/inputs/input-types/fhir-input-time.tsx
@@ -8,6 +8,7 @@ export function MantineFhirInputTime(
   return (
     <TimeInput
       className={props.className}
+      style={props.style}
       label={props.label}
       description={props.description}
       error={props.error}

--- a/packages/mantine/src/r5/navigation/fhir-pagination.tsx
+++ b/packages/mantine/src/r5/navigation/fhir-pagination.tsx
@@ -15,6 +15,9 @@ export function MantineFhirPagination(
       classNames={{
         control: props.className,
       }}
+      styles={{
+        control: props.style,
+      }}
       total={props.totalPages}
       value={props.pageNumber}
       disabled={props.totalPages === 0}

--- a/packages/mantine/src/r5/navigation/fhir-pagination.tsx
+++ b/packages/mantine/src/r5/navigation/fhir-pagination.tsx
@@ -12,6 +12,9 @@ export function MantineFhirPagination(
 ): ReactElement | null {
   return (
     <Pagination.Root
+      classNames={{
+        control: props.className,
+      }}
       total={props.totalPages}
       value={props.pageNumber}
       disabled={props.totalPages === 0}

--- a/packages/react/src/r4b/data-display/fhir-table.tsx
+++ b/packages/react/src/r4b/data-display/fhir-table.tsx
@@ -17,6 +17,7 @@ export interface FhirTableProps<
 > {
   data: TData | undefined;
   className?: string | undefined;
+  style?: Record<string, any> | undefined;
   columns: FhirTableColumn<TRow>[];
   sort?: string | null | undefined;
   onSortChange?: ((sort: string) => void) | null | undefined;

--- a/packages/react/src/r4b/data-display/fhir-table.tsx
+++ b/packages/react/src/r4b/data-display/fhir-table.tsx
@@ -16,6 +16,7 @@ export interface FhirTableProps<
     : never,
 > {
   data: TData | undefined;
+  className?: string | undefined;
   columns: FhirTableColumn<TRow>[];
   sort?: string | null | undefined;
   onSortChange?: ((sort: string) => void) | null | undefined;

--- a/packages/react/src/r4b/data-display/fhir-value.tsx
+++ b/packages/react/src/r4b/data-display/fhir-value.tsx
@@ -9,6 +9,7 @@ import { useFhirUIContext } from "../context";
 
 export type FhirValueProps<TRendererProps = any> =
   DefaultFormatterParametersProps & {
+    className?: string | undefined;
     rendererProps?: TRendererProps;
   };
 

--- a/packages/react/src/r4b/data-display/fhir-value.tsx
+++ b/packages/react/src/r4b/data-display/fhir-value.tsx
@@ -10,6 +10,7 @@ import { useFhirUIContext } from "../context";
 export type FhirValueProps<TRendererProps = any> =
   DefaultFormatterParametersProps & {
     className?: string | undefined;
+    style?: Record<string, any> | undefined;
     rendererProps?: TRendererProps;
   };
 

--- a/packages/react/src/r4b/feedback/fhir-error.tsx
+++ b/packages/react/src/r4b/feedback/fhir-error.tsx
@@ -3,6 +3,7 @@ import { ReactElement } from "react";
 import { useFhirUIContext } from "../context";
 
 export interface FhirErrorProps<TRendererProps = any> {
+  className?: string | undefined;
   error?: unknown;
   onRetry?: () => void;
   rendererProps?: TRendererProps;

--- a/packages/react/src/r4b/feedback/fhir-error.tsx
+++ b/packages/react/src/r4b/feedback/fhir-error.tsx
@@ -4,6 +4,7 @@ import { useFhirUIContext } from "../context";
 
 export interface FhirErrorProps<TRendererProps = any> {
   className?: string | undefined;
+  style?: Record<string, any> | undefined;
   error?: unknown;
   onRetry?: () => void;
   rendererProps?: TRendererProps;

--- a/packages/react/src/r4b/feedback/fhir-query-loader.tsx
+++ b/packages/react/src/r4b/feedback/fhir-query-loader.tsx
@@ -20,6 +20,7 @@ export type FhirQueryLoaderProps<TRendererProps, TData> = {
   error?: ((error: FhirClientError | Error) => ReactElement) | null | undefined;
   children?: ReactNode | ((data: TData) => ReactNode) | undefined;
   className?: string | undefined;
+  style?: Record<string, any> | undefined;
   rendererProps?: TRendererProps;
 };
 

--- a/packages/react/src/r4b/feedback/fhir-query-loader.tsx
+++ b/packages/react/src/r4b/feedback/fhir-query-loader.tsx
@@ -19,6 +19,7 @@ export type FhirQueryLoaderProps<TRendererProps, TData> = {
   loader?: ReactElement | null | undefined;
   error?: ((error: FhirClientError | Error) => ReactElement) | null | undefined;
   children?: ReactNode | ((data: TData) => ReactNode) | undefined;
+  className?: string | undefined;
   rendererProps?: TRendererProps;
 };
 

--- a/packages/react/src/r4b/inputs/fhir-input-array.tsx
+++ b/packages/react/src/r4b/inputs/fhir-input-array.tsx
@@ -19,6 +19,7 @@ export interface FhirInputArrayProps<TValue, TRendererProps = any> {
   onAdd?: (index: number) => void;
   canAdd?: ((value: TValue, index: number) => boolean) | null | undefined;
   onRemove?: (index: number) => void;
+  className?: string | undefined;
   rendererProps?: TRendererProps;
 }
 

--- a/packages/react/src/r4b/inputs/fhir-input-array.tsx
+++ b/packages/react/src/r4b/inputs/fhir-input-array.tsx
@@ -20,6 +20,7 @@ export interface FhirInputArrayProps<TValue, TRendererProps = any> {
   canAdd?: ((value: TValue, index: number) => boolean) | null | undefined;
   onRemove?: (index: number) => void;
   className?: string | undefined;
+  style?: Record<string, any> | undefined;
   rendererProps?: TRendererProps;
 }
 

--- a/packages/react/src/r4b/inputs/fhir-questionnaire.tsx
+++ b/packages/react/src/r4b/inputs/fhir-questionnaire.tsx
@@ -27,6 +27,7 @@ export interface FhirQuestionnaireProps<TRendererProps = any> {
   onSubmit?: ((value: QuestionnaireResponse) => void) | null | undefined;
   onCancel?: (() => void) | null | undefined;
   className?: string | undefined;
+  style?: Record<string, any> | undefined;
   rendererProps?: TRendererProps;
 }
 

--- a/packages/react/src/r4b/inputs/fhir-questionnaire.tsx
+++ b/packages/react/src/r4b/inputs/fhir-questionnaire.tsx
@@ -26,6 +26,7 @@ export interface FhirQuestionnaireProps<TRendererProps = any> {
     | undefined;
   onSubmit?: ((value: QuestionnaireResponse) => void) | null | undefined;
   onCancel?: (() => void) | null | undefined;
+  className?: string | undefined;
   rendererProps?: TRendererProps;
 }
 

--- a/packages/react/src/r4b/inputs/input-types/fhir-input-boolean.tsx
+++ b/packages/react/src/r4b/inputs/input-types/fhir-input-boolean.tsx
@@ -8,6 +8,7 @@ export interface FhirInputBooleanProps<TRendererProps = any>
   mode?: "checkbox" | "switch";
   value?: boolean | null | undefined;
   onChange?: (value: boolean | undefined) => void;
+  className?: string | undefined;
   rendererProps?: TRendererProps;
 }
 

--- a/packages/react/src/r4b/inputs/input-types/fhir-input-boolean.tsx
+++ b/packages/react/src/r4b/inputs/input-types/fhir-input-boolean.tsx
@@ -9,6 +9,7 @@ export interface FhirInputBooleanProps<TRendererProps = any>
   value?: boolean | null | undefined;
   onChange?: (value: boolean | undefined) => void;
   className?: string | undefined;
+  style?: Record<string, any> | undefined;
   rendererProps?: TRendererProps;
 }
 

--- a/packages/react/src/r4b/inputs/input-types/fhir-input-contact-point.tsx
+++ b/packages/react/src/r4b/inputs/input-types/fhir-input-contact-point.tsx
@@ -10,6 +10,7 @@ export interface FhirInputContactPointProps<TRendererProps = any>
   value?: ContactPoint | null | undefined;
   onChange?: (value: ContactPoint | undefined) => void;
   className?: string | undefined;
+  style?: Record<string, any> | undefined;
   rendererProps?: TRendererProps;
 }
 

--- a/packages/react/src/r4b/inputs/input-types/fhir-input-contact-point.tsx
+++ b/packages/react/src/r4b/inputs/input-types/fhir-input-contact-point.tsx
@@ -9,6 +9,7 @@ export interface FhirInputContactPointProps<TRendererProps = any>
   mode?: "full" | "simple" | Array<"system" | "value" | "use">;
   value?: ContactPoint | null | undefined;
   onChange?: (value: ContactPoint | undefined) => void;
+  className?: string | undefined;
   rendererProps?: TRendererProps;
 }
 

--- a/packages/react/src/r4b/inputs/input-types/fhir-input-date-time.tsx
+++ b/packages/react/src/r4b/inputs/input-types/fhir-input-date-time.tsx
@@ -8,6 +8,7 @@ export interface FhirInputDateTimeProps<TRendererProps = any>
   placeholder?: string | null | undefined;
   value?: string | null | undefined;
   onChange?: (value: string | undefined) => void;
+  className?: string | undefined;
   rendererProps?: TRendererProps;
 }
 

--- a/packages/react/src/r4b/inputs/input-types/fhir-input-date-time.tsx
+++ b/packages/react/src/r4b/inputs/input-types/fhir-input-date-time.tsx
@@ -9,6 +9,7 @@ export interface FhirInputDateTimeProps<TRendererProps = any>
   value?: string | null | undefined;
   onChange?: (value: string | undefined) => void;
   className?: string | undefined;
+  style?: Record<string, any> | undefined;
   rendererProps?: TRendererProps;
 }
 

--- a/packages/react/src/r4b/inputs/input-types/fhir-input-date.tsx
+++ b/packages/react/src/r4b/inputs/input-types/fhir-input-date.tsx
@@ -9,6 +9,7 @@ export interface FhirInputDateProps<TRendererProps = any>
   value?: string | null | undefined;
   onChange?: (value: string | undefined) => void;
   className?: string | undefined;
+  style?: Record<string, any> | undefined;
   rendererProps?: TRendererProps;
 }
 

--- a/packages/react/src/r4b/inputs/input-types/fhir-input-date.tsx
+++ b/packages/react/src/r4b/inputs/input-types/fhir-input-date.tsx
@@ -8,6 +8,7 @@ export interface FhirInputDateProps<TRendererProps = any>
   placeholder?: string | null | undefined;
   value?: string | null | undefined;
   onChange?: (value: string | undefined) => void;
+  className?: string | undefined;
   rendererProps?: TRendererProps;
 }
 

--- a/packages/react/src/r4b/inputs/input-types/fhir-input-human-name.tsx
+++ b/packages/react/src/r4b/inputs/input-types/fhir-input-human-name.tsx
@@ -19,6 +19,7 @@ export interface FhirInputHumanNameProps<TRendererProps = any>
   separator?: string | null | undefined;
   value?: HumanName | null | undefined;
   onChange?: (value: HumanName | undefined) => void;
+  className?: string | undefined;
   rendererProps?: TRendererProps;
 }
 

--- a/packages/react/src/r4b/inputs/input-types/fhir-input-human-name.tsx
+++ b/packages/react/src/r4b/inputs/input-types/fhir-input-human-name.tsx
@@ -20,6 +20,7 @@ export interface FhirInputHumanNameProps<TRendererProps = any>
   value?: HumanName | null | undefined;
   onChange?: (value: HumanName | undefined) => void;
   className?: string | undefined;
+  style?: Record<string, any> | undefined;
   rendererProps?: TRendererProps;
 }
 

--- a/packages/react/src/r4b/inputs/input-types/fhir-input-identifier.tsx
+++ b/packages/react/src/r4b/inputs/input-types/fhir-input-identifier.tsx
@@ -31,6 +31,7 @@ export interface FhirInputIdentifierProps<TRendererProps = any>
   value?: Identifier | null | undefined;
   onChange?: (value: Identifier | undefined) => void;
   className?: string | undefined;
+  style?: Record<string, any> | undefined;
   rendererProps?: TRendererProps;
 }
 

--- a/packages/react/src/r4b/inputs/input-types/fhir-input-identifier.tsx
+++ b/packages/react/src/r4b/inputs/input-types/fhir-input-identifier.tsx
@@ -30,6 +30,7 @@ export interface FhirInputIdentifierProps<TRendererProps = any>
     | undefined;
   value?: Identifier | null | undefined;
   onChange?: (value: Identifier | undefined) => void;
+  className?: string | undefined;
   rendererProps?: TRendererProps;
 }
 

--- a/packages/react/src/r4b/inputs/input-types/fhir-input-markdown.tsx
+++ b/packages/react/src/r4b/inputs/input-types/fhir-input-markdown.tsx
@@ -8,6 +8,7 @@ export interface FhirInputMarkdownProps<TRendererProps = any>
   placeholder?: string | null | undefined;
   value?: string | null | undefined;
   onChange?: (value: string | undefined) => void;
+  className?: string | undefined;
   rendererProps?: TRendererProps;
 }
 

--- a/packages/react/src/r4b/inputs/input-types/fhir-input-markdown.tsx
+++ b/packages/react/src/r4b/inputs/input-types/fhir-input-markdown.tsx
@@ -9,6 +9,7 @@ export interface FhirInputMarkdownProps<TRendererProps = any>
   value?: string | null | undefined;
   onChange?: (value: string | undefined) => void;
   className?: string | undefined;
+  style?: Record<string, any> | undefined;
   rendererProps?: TRendererProps;
 }
 

--- a/packages/react/src/r4b/inputs/input-types/fhir-input-number.tsx
+++ b/packages/react/src/r4b/inputs/input-types/fhir-input-number.tsx
@@ -10,6 +10,7 @@ export type FhirInputNumberProps<TRendererProps = any> =
     value?: number | null | undefined;
     onChange?: (value: number | undefined) => void;
     className?: string | undefined;
+    style?: Record<string, any> | undefined;
     rendererProps?: TRendererProps;
   } & (
       | {

--- a/packages/react/src/r4b/inputs/input-types/fhir-input-number.tsx
+++ b/packages/react/src/r4b/inputs/input-types/fhir-input-number.tsx
@@ -9,6 +9,7 @@ export type FhirInputNumberProps<TRendererProps = any> =
     step?: number | null | undefined;
     value?: number | null | undefined;
     onChange?: (value: number | undefined) => void;
+    className?: string | undefined;
     rendererProps?: TRendererProps;
   } & (
       | {

--- a/packages/react/src/r4b/inputs/input-types/fhir-input-resource.tsx
+++ b/packages/react/src/r4b/inputs/input-types/fhir-input-resource.tsx
@@ -26,6 +26,7 @@ export type FhirInputResourceProps<
     | ((resource: ExtractResource<TResourceType>) => ReactNode)
     | null
     | undefined;
+  className?: string | undefined;
   rendererProps?: TRendererProps;
 } & (
     | {

--- a/packages/react/src/r4b/inputs/input-types/fhir-input-resource.tsx
+++ b/packages/react/src/r4b/inputs/input-types/fhir-input-resource.tsx
@@ -27,6 +27,7 @@ export type FhirInputResourceProps<
     | null
     | undefined;
   className?: string | undefined;
+  style?: Record<string, any> | undefined;
   rendererProps?: TRendererProps;
 } & (
     | {

--- a/packages/react/src/r4b/inputs/input-types/fhir-input-string.tsx
+++ b/packages/react/src/r4b/inputs/input-types/fhir-input-string.tsx
@@ -8,6 +8,7 @@ export type FhirInputStringProps<TRendererProps = any> =
     value?: string | null | undefined;
     onChange?: (value: string | undefined) => void;
     className?: string | undefined;
+    style?: Record<string, any> | undefined;
     rendererProps?: TRendererProps;
   } & (
       | { type: "canonical" | "id" | "oid" | "uri" | "url" | "uuid" }

--- a/packages/react/src/r4b/inputs/input-types/fhir-input-string.tsx
+++ b/packages/react/src/r4b/inputs/input-types/fhir-input-string.tsx
@@ -7,6 +7,7 @@ export type FhirInputStringProps<TRendererProps = any> =
     placeholder?: string | null | undefined;
     value?: string | null | undefined;
     onChange?: (value: string | undefined) => void;
+    className?: string | undefined;
     rendererProps?: TRendererProps;
   } & (
       | { type: "canonical" | "id" | "oid" | "uri" | "url" | "uuid" }

--- a/packages/react/src/r4b/inputs/input-types/fhir-input-terminology.tsx
+++ b/packages/react/src/r4b/inputs/input-types/fhir-input-terminology.tsx
@@ -23,6 +23,7 @@ export type FhirInputTerminologyProps<TRendererProps = any> =
     ) => number;
     value?: string | null | undefined;
     onChange?: (value: string | undefined) => void;
+    className?: string | undefined;
     rendererProps?: TRendererProps;
   } & {
     mode?: "select" | "radio" | "segmented" | null | undefined;

--- a/packages/react/src/r4b/inputs/input-types/fhir-input-terminology.tsx
+++ b/packages/react/src/r4b/inputs/input-types/fhir-input-terminology.tsx
@@ -24,6 +24,7 @@ export type FhirInputTerminologyProps<TRendererProps = any> =
     value?: string | null | undefined;
     onChange?: (value: string | undefined) => void;
     className?: string | undefined;
+    style?: Record<string, any> | undefined;
     rendererProps?: TRendererProps;
   } & {
     mode?: "select" | "radio" | "segmented" | null | undefined;

--- a/packages/react/src/r4b/inputs/input-types/fhir-input-time.tsx
+++ b/packages/react/src/r4b/inputs/input-types/fhir-input-time.tsx
@@ -8,6 +8,7 @@ export interface FhirInputTimeProps<TRendererProps = any>
   placeholder?: string | null | undefined;
   value?: string | null | undefined;
   onChange?: (value: string | undefined) => void;
+  className?: string | undefined;
   rendererProps?: TRendererProps;
 }
 

--- a/packages/react/src/r4b/inputs/input-types/fhir-input-time.tsx
+++ b/packages/react/src/r4b/inputs/input-types/fhir-input-time.tsx
@@ -9,6 +9,7 @@ export interface FhirInputTimeProps<TRendererProps = any>
   value?: string | null | undefined;
   onChange?: (value: string | undefined) => void;
   className?: string | undefined;
+  style?: Record<string, any> | undefined;
   rendererProps?: TRendererProps;
 }
 

--- a/packages/react/src/r4b/navigation/fhir-pagination.tsx
+++ b/packages/react/src/r4b/navigation/fhir-pagination.tsx
@@ -24,6 +24,7 @@ export interface FhirPaginationProps<TRendererProps = any> {
    *  - totalPages
    */
   textTemplate?: string | null | undefined;
+  className?: string | undefined;
   rendererProps?: TRendererProps;
 }
 

--- a/packages/react/src/r4b/navigation/fhir-pagination.tsx
+++ b/packages/react/src/r4b/navigation/fhir-pagination.tsx
@@ -25,6 +25,7 @@ export interface FhirPaginationProps<TRendererProps = any> {
    */
   textTemplate?: string | null | undefined;
   className?: string | undefined;
+  style?: Record<string, any> | undefined;
   rendererProps?: TRendererProps;
 }
 

--- a/packages/react/src/r5/data-display/fhir-table.tsx
+++ b/packages/react/src/r5/data-display/fhir-table.tsx
@@ -17,6 +17,7 @@ export interface FhirTableProps<
 > {
   data: TData | undefined;
   className?: string | undefined;
+  style?: Record<string, any> | undefined;
   columns: FhirTableColumn<TRow>[];
   sort?: string | null | undefined;
   onSortChange?: ((sort: string) => void) | null | undefined;

--- a/packages/react/src/r5/data-display/fhir-table.tsx
+++ b/packages/react/src/r5/data-display/fhir-table.tsx
@@ -16,6 +16,7 @@ export interface FhirTableProps<
     : never,
 > {
   data: TData | undefined;
+  className?: string | undefined;
   columns: FhirTableColumn<TRow>[];
   sort?: string | null | undefined;
   onSortChange?: ((sort: string) => void) | null | undefined;

--- a/packages/react/src/r5/data-display/fhir-value.tsx
+++ b/packages/react/src/r5/data-display/fhir-value.tsx
@@ -9,6 +9,7 @@ import { useFhirUIContext } from "../context";
 
 export type FhirValueProps<TRendererProps = any> =
   DefaultFormatterParametersProps & {
+    className?: string | undefined;
     rendererProps?: TRendererProps;
   };
 

--- a/packages/react/src/r5/data-display/fhir-value.tsx
+++ b/packages/react/src/r5/data-display/fhir-value.tsx
@@ -10,6 +10,7 @@ import { useFhirUIContext } from "../context";
 export type FhirValueProps<TRendererProps = any> =
   DefaultFormatterParametersProps & {
     className?: string | undefined;
+    style?: Record<string, any> | undefined;
     rendererProps?: TRendererProps;
   };
 

--- a/packages/react/src/r5/feedback/fhir-error.tsx
+++ b/packages/react/src/r5/feedback/fhir-error.tsx
@@ -3,6 +3,7 @@ import { ReactElement } from "react";
 import { useFhirUIContext } from "../context";
 
 export interface FhirErrorProps<TRendererProps = any> {
+  className?: string | undefined;
   error?: unknown;
   onRetry?: () => void;
   rendererProps?: TRendererProps;

--- a/packages/react/src/r5/feedback/fhir-error.tsx
+++ b/packages/react/src/r5/feedback/fhir-error.tsx
@@ -4,6 +4,7 @@ import { useFhirUIContext } from "../context";
 
 export interface FhirErrorProps<TRendererProps = any> {
   className?: string | undefined;
+  style?: Record<string, any> | undefined;
   error?: unknown;
   onRetry?: () => void;
   rendererProps?: TRendererProps;

--- a/packages/react/src/r5/feedback/fhir-query-loader.tsx
+++ b/packages/react/src/r5/feedback/fhir-query-loader.tsx
@@ -20,6 +20,7 @@ export type FhirQueryLoaderProps<TRendererProps, TData> = {
   error?: ((error: FhirClientError | Error) => ReactElement) | null | undefined;
   children?: ReactNode | ((data: TData) => ReactNode) | undefined;
   className?: string | undefined;
+  style?: Record<string, any> | undefined;
   rendererProps?: TRendererProps;
 };
 

--- a/packages/react/src/r5/feedback/fhir-query-loader.tsx
+++ b/packages/react/src/r5/feedback/fhir-query-loader.tsx
@@ -19,6 +19,7 @@ export type FhirQueryLoaderProps<TRendererProps, TData> = {
   loader?: ReactElement | null | undefined;
   error?: ((error: FhirClientError | Error) => ReactElement) | null | undefined;
   children?: ReactNode | ((data: TData) => ReactNode) | undefined;
+  className?: string | undefined;
   rendererProps?: TRendererProps;
 };
 

--- a/packages/react/src/r5/inputs/fhir-input-array.tsx
+++ b/packages/react/src/r5/inputs/fhir-input-array.tsx
@@ -19,6 +19,7 @@ export interface FhirInputArrayProps<TValue, TRendererProps = any> {
   onAdd?: (index: number) => void;
   canAdd?: ((value: TValue, index: number) => boolean) | null | undefined;
   onRemove?: (index: number) => void;
+  className?: string | undefined;
   rendererProps?: TRendererProps;
 }
 

--- a/packages/react/src/r5/inputs/fhir-input-array.tsx
+++ b/packages/react/src/r5/inputs/fhir-input-array.tsx
@@ -20,6 +20,7 @@ export interface FhirInputArrayProps<TValue, TRendererProps = any> {
   canAdd?: ((value: TValue, index: number) => boolean) | null | undefined;
   onRemove?: (index: number) => void;
   className?: string | undefined;
+  style?: Record<string, any> | undefined;
   rendererProps?: TRendererProps;
 }
 

--- a/packages/react/src/r5/inputs/fhir-questionnaire.tsx
+++ b/packages/react/src/r5/inputs/fhir-questionnaire.tsx
@@ -27,6 +27,7 @@ export interface FhirQuestionnaireProps<TRendererProps = any> {
   onSubmit?: ((value: QuestionnaireResponse) => void) | null | undefined;
   onCancel?: (() => void) | null | undefined;
   className?: string | undefined;
+  style?: Record<string, any> | undefined;
   rendererProps?: TRendererProps;
 }
 

--- a/packages/react/src/r5/inputs/fhir-questionnaire.tsx
+++ b/packages/react/src/r5/inputs/fhir-questionnaire.tsx
@@ -26,6 +26,7 @@ export interface FhirQuestionnaireProps<TRendererProps = any> {
     | undefined;
   onSubmit?: ((value: QuestionnaireResponse) => void) | null | undefined;
   onCancel?: (() => void) | null | undefined;
+  className?: string | undefined;
   rendererProps?: TRendererProps;
 }
 

--- a/packages/react/src/r5/inputs/input-types/fhir-input-boolean.tsx
+++ b/packages/react/src/r5/inputs/input-types/fhir-input-boolean.tsx
@@ -8,6 +8,7 @@ export interface FhirInputBooleanProps<TRendererProps = any>
   mode?: "checkbox" | "switch";
   value?: boolean | null | undefined;
   onChange?: (value: boolean | undefined) => void;
+  className?: string | undefined;
   rendererProps?: TRendererProps;
 }
 

--- a/packages/react/src/r5/inputs/input-types/fhir-input-boolean.tsx
+++ b/packages/react/src/r5/inputs/input-types/fhir-input-boolean.tsx
@@ -9,6 +9,7 @@ export interface FhirInputBooleanProps<TRendererProps = any>
   value?: boolean | null | undefined;
   onChange?: (value: boolean | undefined) => void;
   className?: string | undefined;
+  style?: Record<string, any> | undefined;
   rendererProps?: TRendererProps;
 }
 

--- a/packages/react/src/r5/inputs/input-types/fhir-input-contact-point.tsx
+++ b/packages/react/src/r5/inputs/input-types/fhir-input-contact-point.tsx
@@ -10,6 +10,7 @@ export interface FhirInputContactPointProps<TRendererProps = any>
   value?: ContactPoint | null | undefined;
   onChange?: (value: ContactPoint | undefined) => void;
   className?: string | undefined;
+  style?: Record<string, any> | undefined;
   rendererProps?: TRendererProps;
 }
 

--- a/packages/react/src/r5/inputs/input-types/fhir-input-contact-point.tsx
+++ b/packages/react/src/r5/inputs/input-types/fhir-input-contact-point.tsx
@@ -9,6 +9,7 @@ export interface FhirInputContactPointProps<TRendererProps = any>
   mode?: "full" | "simple" | Array<"system" | "value" | "use">;
   value?: ContactPoint | null | undefined;
   onChange?: (value: ContactPoint | undefined) => void;
+  className?: string | undefined;
   rendererProps?: TRendererProps;
 }
 

--- a/packages/react/src/r5/inputs/input-types/fhir-input-date-time.tsx
+++ b/packages/react/src/r5/inputs/input-types/fhir-input-date-time.tsx
@@ -8,6 +8,7 @@ export interface FhirInputDateTimeProps<TRendererProps = any>
   placeholder?: string | null | undefined;
   value?: string | null | undefined;
   onChange?: (value: string | undefined) => void;
+  className?: string | undefined;
   rendererProps?: TRendererProps;
 }
 

--- a/packages/react/src/r5/inputs/input-types/fhir-input-date-time.tsx
+++ b/packages/react/src/r5/inputs/input-types/fhir-input-date-time.tsx
@@ -9,6 +9,7 @@ export interface FhirInputDateTimeProps<TRendererProps = any>
   value?: string | null | undefined;
   onChange?: (value: string | undefined) => void;
   className?: string | undefined;
+  style?: Record<string, any> | undefined;
   rendererProps?: TRendererProps;
 }
 

--- a/packages/react/src/r5/inputs/input-types/fhir-input-date.tsx
+++ b/packages/react/src/r5/inputs/input-types/fhir-input-date.tsx
@@ -9,6 +9,7 @@ export interface FhirInputDateProps<TRendererProps = any>
   value?: string | null | undefined;
   onChange?: (value: string | undefined) => void;
   className?: string | undefined;
+  style?: Record<string, any> | undefined;
   rendererProps?: TRendererProps;
 }
 

--- a/packages/react/src/r5/inputs/input-types/fhir-input-date.tsx
+++ b/packages/react/src/r5/inputs/input-types/fhir-input-date.tsx
@@ -8,6 +8,7 @@ export interface FhirInputDateProps<TRendererProps = any>
   placeholder?: string | null | undefined;
   value?: string | null | undefined;
   onChange?: (value: string | undefined) => void;
+  className?: string | undefined;
   rendererProps?: TRendererProps;
 }
 

--- a/packages/react/src/r5/inputs/input-types/fhir-input-human-name.tsx
+++ b/packages/react/src/r5/inputs/input-types/fhir-input-human-name.tsx
@@ -19,6 +19,7 @@ export interface FhirInputHumanNameProps<TRendererProps = any>
   separator?: string | null | undefined;
   value?: HumanName | null | undefined;
   onChange?: (value: HumanName | undefined) => void;
+  className?: string | undefined;
   rendererProps?: TRendererProps;
 }
 

--- a/packages/react/src/r5/inputs/input-types/fhir-input-human-name.tsx
+++ b/packages/react/src/r5/inputs/input-types/fhir-input-human-name.tsx
@@ -20,6 +20,7 @@ export interface FhirInputHumanNameProps<TRendererProps = any>
   value?: HumanName | null | undefined;
   onChange?: (value: HumanName | undefined) => void;
   className?: string | undefined;
+  style?: Record<string, any> | undefined;
   rendererProps?: TRendererProps;
 }
 

--- a/packages/react/src/r5/inputs/input-types/fhir-input-identifier.tsx
+++ b/packages/react/src/r5/inputs/input-types/fhir-input-identifier.tsx
@@ -31,6 +31,7 @@ export interface FhirInputIdentifierProps<TRendererProps = any>
   value?: Identifier | null | undefined;
   onChange?: (value: Identifier | undefined) => void;
   className?: string | undefined;
+  style?: Record<string, any> | undefined;
   rendererProps?: TRendererProps;
 }
 

--- a/packages/react/src/r5/inputs/input-types/fhir-input-identifier.tsx
+++ b/packages/react/src/r5/inputs/input-types/fhir-input-identifier.tsx
@@ -30,6 +30,7 @@ export interface FhirInputIdentifierProps<TRendererProps = any>
     | undefined;
   value?: Identifier | null | undefined;
   onChange?: (value: Identifier | undefined) => void;
+  className?: string | undefined;
   rendererProps?: TRendererProps;
 }
 

--- a/packages/react/src/r5/inputs/input-types/fhir-input-markdown.tsx
+++ b/packages/react/src/r5/inputs/input-types/fhir-input-markdown.tsx
@@ -8,6 +8,7 @@ export interface FhirInputMarkdownProps<TRendererProps = any>
   placeholder?: string | null | undefined;
   value?: string | null | undefined;
   onChange?: (value: string | undefined) => void;
+  className?: string | undefined;
   rendererProps?: TRendererProps;
 }
 

--- a/packages/react/src/r5/inputs/input-types/fhir-input-markdown.tsx
+++ b/packages/react/src/r5/inputs/input-types/fhir-input-markdown.tsx
@@ -9,6 +9,7 @@ export interface FhirInputMarkdownProps<TRendererProps = any>
   value?: string | null | undefined;
   onChange?: (value: string | undefined) => void;
   className?: string | undefined;
+  style?: Record<string, any> | undefined;
   rendererProps?: TRendererProps;
 }
 

--- a/packages/react/src/r5/inputs/input-types/fhir-input-number.tsx
+++ b/packages/react/src/r5/inputs/input-types/fhir-input-number.tsx
@@ -10,6 +10,7 @@ export type FhirInputNumberProps<TRendererProps = any> =
     value?: number | null | undefined;
     onChange?: (value: number | undefined) => void;
     className?: string | undefined;
+    style?: Record<string, any> | undefined;
     rendererProps?: TRendererProps;
   } & (
       | {

--- a/packages/react/src/r5/inputs/input-types/fhir-input-number.tsx
+++ b/packages/react/src/r5/inputs/input-types/fhir-input-number.tsx
@@ -9,6 +9,7 @@ export type FhirInputNumberProps<TRendererProps = any> =
     step?: number | null | undefined;
     value?: number | null | undefined;
     onChange?: (value: number | undefined) => void;
+    className?: string | undefined;
     rendererProps?: TRendererProps;
   } & (
       | {

--- a/packages/react/src/r5/inputs/input-types/fhir-input-resource.tsx
+++ b/packages/react/src/r5/inputs/input-types/fhir-input-resource.tsx
@@ -26,6 +26,7 @@ export type FhirInputResourceProps<
     | ((resource: ExtractResource<TResourceType>) => ReactNode)
     | null
     | undefined;
+  className?: string | undefined;
   rendererProps?: TRendererProps;
 } & (
     | {

--- a/packages/react/src/r5/inputs/input-types/fhir-input-resource.tsx
+++ b/packages/react/src/r5/inputs/input-types/fhir-input-resource.tsx
@@ -27,6 +27,7 @@ export type FhirInputResourceProps<
     | null
     | undefined;
   className?: string | undefined;
+  style?: Record<string, any> | undefined;
   rendererProps?: TRendererProps;
 } & (
     | {

--- a/packages/react/src/r5/inputs/input-types/fhir-input-string.tsx
+++ b/packages/react/src/r5/inputs/input-types/fhir-input-string.tsx
@@ -8,6 +8,7 @@ export type FhirInputStringProps<TRendererProps = any> =
     value?: string | null | undefined;
     onChange?: (value: string | undefined) => void;
     className?: string | undefined;
+    style?: Record<string, any> | undefined;
     rendererProps?: TRendererProps;
   } & (
       | { type: "canonical" | "id" | "oid" | "uri" | "url" | "uuid" }

--- a/packages/react/src/r5/inputs/input-types/fhir-input-string.tsx
+++ b/packages/react/src/r5/inputs/input-types/fhir-input-string.tsx
@@ -7,6 +7,7 @@ export type FhirInputStringProps<TRendererProps = any> =
     placeholder?: string | null | undefined;
     value?: string | null | undefined;
     onChange?: (value: string | undefined) => void;
+    className?: string | undefined;
     rendererProps?: TRendererProps;
   } & (
       | { type: "canonical" | "id" | "oid" | "uri" | "url" | "uuid" }

--- a/packages/react/src/r5/inputs/input-types/fhir-input-terminology.tsx
+++ b/packages/react/src/r5/inputs/input-types/fhir-input-terminology.tsx
@@ -23,6 +23,7 @@ export type FhirInputTerminologyProps<TRendererProps = any> =
     ) => number;
     value?: string | null | undefined;
     onChange?: (value: string | undefined) => void;
+    className?: string | undefined;
     rendererProps?: TRendererProps;
   } & {
     mode?: "select" | "radio" | "segmented" | null | undefined;

--- a/packages/react/src/r5/inputs/input-types/fhir-input-terminology.tsx
+++ b/packages/react/src/r5/inputs/input-types/fhir-input-terminology.tsx
@@ -24,6 +24,7 @@ export type FhirInputTerminologyProps<TRendererProps = any> =
     value?: string | null | undefined;
     onChange?: (value: string | undefined) => void;
     className?: string | undefined;
+    style?: Record<string, any> | undefined;
     rendererProps?: TRendererProps;
   } & {
     mode?: "select" | "radio" | "segmented" | null | undefined;

--- a/packages/react/src/r5/inputs/input-types/fhir-input-time.tsx
+++ b/packages/react/src/r5/inputs/input-types/fhir-input-time.tsx
@@ -8,6 +8,7 @@ export interface FhirInputTimeProps<TRendererProps = any>
   placeholder?: string | null | undefined;
   value?: string | null | undefined;
   onChange?: (value: string | undefined) => void;
+  className?: string | undefined;
   rendererProps?: TRendererProps;
 }
 

--- a/packages/react/src/r5/inputs/input-types/fhir-input-time.tsx
+++ b/packages/react/src/r5/inputs/input-types/fhir-input-time.tsx
@@ -9,6 +9,7 @@ export interface FhirInputTimeProps<TRendererProps = any>
   value?: string | null | undefined;
   onChange?: (value: string | undefined) => void;
   className?: string | undefined;
+  style?: Record<string, any> | undefined;
   rendererProps?: TRendererProps;
 }
 

--- a/packages/react/src/r5/navigation/fhir-pagination.tsx
+++ b/packages/react/src/r5/navigation/fhir-pagination.tsx
@@ -24,6 +24,7 @@ export interface FhirPaginationProps<TRendererProps = any> {
    *  - totalPages
    */
   textTemplate?: string | null | undefined;
+  className?: string | undefined;
   rendererProps?: TRendererProps;
 }
 

--- a/packages/react/src/r5/navigation/fhir-pagination.tsx
+++ b/packages/react/src/r5/navigation/fhir-pagination.tsx
@@ -25,6 +25,7 @@ export interface FhirPaginationProps<TRendererProps = any> {
    */
   textTemplate?: string | null | undefined;
   className?: string | undefined;
+  style?: Record<string, any> | undefined;
   rendererProps?: TRendererProps;
 }
 


### PR DESCRIPTION
Fix #81.

This is to simplify usage of general styling, without having to reach for the more complex `rendererProps`.
This should be enough to ease usage for things like margin, etc.

I opted for a very general `style` type to cather to all possible implementations, including react-native.