### PR TITLE
Fix #88: add support for GraphQL Execution Result / partial errors

### DIFF
--- a/.changeset/good-guests-kneel.md
+++ b/.changeset/good-guests-kneel.md
@@ -1,0 +1,6 @@
+---
+"@bonfhir/query": minor
+"@bonfhir/core": minor
+---
+
+Fix #88: add support for GraphQL Execution Result / partial errors

--- a/packages/core/src/r4b/fetch-fhir-client.ts
+++ b/packages/core/src/r4b/fetch-fhir-client.ts
@@ -547,24 +547,10 @@ export class FetchFhirClient implements FhirClient {
     variables?: TVariables,
     operationName?: string | null | undefined,
   ): Promise<TResult> {
-    if (typeof query !== "string") {
-      query = print(query);
-    }
-
-    const response = await this.fetch<GraphQLExecutionResult<TResult>>(
-      "$graphql",
-      {
-        method: "POST",
-        body: JSON.stringify({
-          query,
-          variables,
-          operationName,
-        }),
-        headers: {
-          Accept: "application/json",
-          "Content-Type": "application/json",
-        },
-      },
+    const response = await this.graphqlResult<TResult, TVariables>(
+      query,
+      variables,
+      operationName,
     );
 
     if (response.errors?.length) {
@@ -584,6 +570,43 @@ export class FetchFhirClient implements FhirClient {
     }
 
     return response.data!;
+  }
+
+  public async graphqlResult<TResult = any>(
+    query: string,
+    variables?: Record<string, any>,
+    operationName?: string | null | undefined,
+  ): Promise<GraphQLExecutionResult<TResult>>;
+  public async graphqlResult<TResult = any, TVariables = Record<string, any>>(
+    query: TypedDocumentNode<TResult, TVariables>,
+    variables?: TVariables,
+  ): Promise<GraphQLExecutionResult<TResult>>;
+  public async graphqlResult<TResult = any, TVariables = Record<string, any>>(
+    query: string | TypedDocumentNode<TResult, TVariables>,
+    variables?: TVariables,
+    operationName?: string | null | undefined,
+  ): Promise<GraphQLExecutionResult<TResult>>;
+  public async graphqlResult<TResult = any, TVariables = Record<string, any>>(
+    query: string | TypedDocumentNode<TResult, TVariables>,
+    variables?: TVariables,
+    operationName?: string | null | undefined,
+  ): Promise<GraphQLExecutionResult<TResult>> {
+    if (typeof query !== "string") {
+      query = print(query);
+    }
+
+    return await this.fetch<GraphQLExecutionResult<TResult>>("$graphql", {
+      method: "POST",
+      body: JSON.stringify({
+        query,
+        variables,
+        operationName,
+      }),
+      headers: {
+        Accept: "application/json",
+        "Content-Type": "application/json",
+      },
+    });
   }
   /* eslint-enable @typescript-eslint/no-explicit-any */
 

--- a/packages/core/src/r4b/fhir-client.ts
+++ b/packages/core/src/r4b/fhir-client.ts
@@ -1,5 +1,6 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
 import type { TypedDocumentNode } from "@graphql-typed-document-node/core";
+import { ExecutionResult } from "graphql";
 import { BundleExecutor } from "./bundle-executor";
 import { BundleNavigator, WithResolvableReferences } from "./bundle-navigator";
 import {
@@ -229,6 +230,12 @@ export interface FhirClient {
 
   /**
    * Execute a [$graphql operation](https://hl7.org/fhir/resource-operation-graphql.html).
+   *
+   * This methods throws a `FhirClientError` if there are GraphQL errors in the response.
+   * This make it easier to reason about, but do not support partial errors in GraphQL.
+   *
+   * Use the {@link graphqlResult} method to have access to the raw GraphQL response,
+   * including the `errors` and `extensions` field.
    */
   graphql<TResult = any>(
     query: string,
@@ -239,6 +246,25 @@ export interface FhirClient {
     query: TypedDocumentNode<TResult, TVariables>,
     variables?: TVariables,
   ): Promise<TResult>;
+
+  /**
+   * Execute a [$graphql operation](https://hl7.org/fhir/resource-operation-graphql.html).
+   *
+   * This methods returns the "raw" GraphQL ExecutionResult, including the `errors` and `extensions` field.
+   * It does not throw if there are GraphQL errors in the response - it is up to the caller to handle them.
+   *
+   * Use the {@link graphql} method to have a simpler API that throws a `FhirClientError`
+   * whenever there are GraphQL errors.
+   */
+  graphqlResult<TResult = any>(
+    query: string,
+    variables?: Record<string, any>,
+    operationName?: string | null | undefined,
+  ): Promise<ExecutionResult<TResult>>;
+  graphqlResult<TResult = any, TVariables = Record<string, any>>(
+    query: TypedDocumentNode<TResult, TVariables>,
+    variables?: TVariables,
+  ): Promise<ExecutionResult<TResult>>;
 
   /**
    * The capabilities interaction retrieves the information about a server's capabilities - which portions of this specification it supports.

--- a/packages/core/src/r5/fetch-fhir-client.ts
+++ b/packages/core/src/r5/fetch-fhir-client.ts
@@ -547,24 +547,10 @@ export class FetchFhirClient implements FhirClient {
     variables?: TVariables,
     operationName?: string | null | undefined,
   ): Promise<TResult> {
-    if (typeof query !== "string") {
-      query = print(query);
-    }
-
-    const response = await this.fetch<GraphQLExecutionResult<TResult>>(
-      "$graphql",
-      {
-        method: "POST",
-        body: JSON.stringify({
-          query,
-          variables,
-          operationName,
-        }),
-        headers: {
-          Accept: "application/json",
-          "Content-Type": "application/json",
-        },
-      },
+    const response = await this.graphqlResult<TResult, TVariables>(
+      query,
+      variables,
+      operationName,
     );
 
     if (response.errors?.length) {
@@ -584,6 +570,43 @@ export class FetchFhirClient implements FhirClient {
     }
 
     return response.data!;
+  }
+
+  public async graphqlResult<TResult = any>(
+    query: string,
+    variables?: Record<string, any>,
+    operationName?: string | null | undefined,
+  ): Promise<GraphQLExecutionResult<TResult>>;
+  public async graphqlResult<TResult = any, TVariables = Record<string, any>>(
+    query: TypedDocumentNode<TResult, TVariables>,
+    variables?: TVariables,
+  ): Promise<GraphQLExecutionResult<TResult>>;
+  public async graphqlResult<TResult = any, TVariables = Record<string, any>>(
+    query: string | TypedDocumentNode<TResult, TVariables>,
+    variables?: TVariables,
+    operationName?: string | null | undefined,
+  ): Promise<GraphQLExecutionResult<TResult>>;
+  public async graphqlResult<TResult = any, TVariables = Record<string, any>>(
+    query: string | TypedDocumentNode<TResult, TVariables>,
+    variables?: TVariables,
+    operationName?: string | null | undefined,
+  ): Promise<GraphQLExecutionResult<TResult>> {
+    if (typeof query !== "string") {
+      query = print(query);
+    }
+
+    return await this.fetch<GraphQLExecutionResult<TResult>>("$graphql", {
+      method: "POST",
+      body: JSON.stringify({
+        query,
+        variables,
+        operationName,
+      }),
+      headers: {
+        Accept: "application/json",
+        "Content-Type": "application/json",
+      },
+    });
   }
   /* eslint-enable @typescript-eslint/no-explicit-any */
 

--- a/packages/core/src/r5/fhir-client.ts
+++ b/packages/core/src/r5/fhir-client.ts
@@ -1,5 +1,6 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
 import type { TypedDocumentNode } from "@graphql-typed-document-node/core";
+import { ExecutionResult } from "graphql";
 import { BundleExecutor } from "./bundle-executor";
 import { BundleNavigator, WithResolvableReferences } from "./bundle-navigator";
 import {
@@ -229,6 +230,12 @@ export interface FhirClient {
 
   /**
    * Execute a [$graphql operation](https://hl7.org/fhir/resource-operation-graphql.html).
+   *
+   * This methods throws a `FhirClientError` if there are GraphQL errors in the response.
+   * This make it easier to reason about, but do not support partial errors in GraphQL.
+   *
+   * Use the {@link graphqlResult} method to have access to the raw GraphQL response,
+   * including the `errors` and `extensions` field.
    */
   graphql<TResult = any>(
     query: string,
@@ -239,6 +246,25 @@ export interface FhirClient {
     query: TypedDocumentNode<TResult, TVariables>,
     variables?: TVariables,
   ): Promise<TResult>;
+
+  /**
+   * Execute a [$graphql operation](https://hl7.org/fhir/resource-operation-graphql.html).
+   *
+   * This methods returns the "raw" GraphQL ExecutionResult, including the `errors` and `extensions` field.
+   * It does not throw if there are GraphQL errors in the response - it is up to the caller to handle them.
+   *
+   * Use the {@link graphql} method to have a simpler API that throws a `FhirClientError`
+   * whenever there are GraphQL errors.
+   */
+  graphqlResult<TResult = any>(
+    query: string,
+    variables?: Record<string, any>,
+    operationName?: string | null | undefined,
+  ): Promise<ExecutionResult<TResult>>;
+  graphqlResult<TResult = any, TVariables = Record<string, any>>(
+    query: TypedDocumentNode<TResult, TVariables>,
+    variables?: TVariables,
+  ): Promise<ExecutionResult<TResult>>;
 
   /**
    * The capabilities interaction retrieves the information about a server's capabilities - which portions of this specification it supports.

--- a/packages/query/src/r4b/hooks/index.ts
+++ b/packages/query/src/r4b/hooks/index.ts
@@ -8,6 +8,7 @@ export * from "./use-fhir-execute-mutation";
 export * from "./use-fhir-graph";
 export * from "./use-fhir-graphql";
 export * from "./use-fhir-graphql-mutation";
+export * from "./use-fhir-graphql-result";
 export * from "./use-fhir-history";
 export * from "./use-fhir-infinite-search";
 export * from "./use-fhir-patch-mutation";

--- a/packages/query/src/r4b/hooks/use-fhir-graphql-mutation.tsx
+++ b/packages/query/src/r4b/hooks/use-fhir-graphql-mutation.tsx
@@ -23,6 +23,11 @@ export interface UseFhirGraphQLMutationOptions<
     | undefined;
 }
 
+/**
+ * Execute a [$graphql mutation](https://hl7.org/fhir/resource-operation-graphql.html).
+ *
+ * The mutation is put on error if there are GraphQL errors in the response.
+ */
 export function useFhirGraphQLMutation<TResult = any>(
   query: string,
   operationName?: string | null | undefined,

--- a/packages/query/src/r4b/index.test.tsx
+++ b/packages/query/src/r4b/index.test.tsx
@@ -32,6 +32,7 @@ import {
   useFhirExecuteMutation,
   useFhirGraphQL,
   useFhirGraphQLMutation,
+  useFhirGraphQLResult,
   useFhirHistory,
   useFhirInfiniteSearch,
   useFhirPatchMutation,
@@ -742,6 +743,59 @@ describe("hooks", () => {
             ],
           } satisfies Partial<ListOrganizationsQuery>);
         });
+      });
+    });
+  });
+
+  describe("GraphQLResult", () => {
+    it("execute a query as a string", async () => {
+      const { result } = renderHook(
+        () =>
+          useFhirGraphQLResult(
+            `{
+              Patient(id: "patient-id") {
+                resourceType
+                id
+                name {
+                  given
+                  family
+                }
+              }
+            }`,
+          ),
+        { wrapper },
+      );
+
+      await waitFor(() => {
+        expect(result.current.isSuccess).toBeTruthy();
+        expect(result.current.data?.data).toMatchObject({
+          Patient: {
+            resourceType: "Patient",
+            id: expect.stringMatching(/.+/),
+          },
+        });
+      });
+    });
+
+    it("execute a query as a document", async () => {
+      const { result } = renderHook(
+        () =>
+          useFhirGraphQLResult(ListOrganizationsDocument, {
+            name: "Acme, Inc",
+          }),
+        { wrapper },
+      );
+
+      await waitFor(() => {
+        expect(result.current.isSuccess).toBeTruthy();
+        expect(result.current.data?.data).toMatchObject({
+          OrganizationList: [
+            {
+              resourceType: "Organization",
+              name: "Acme, Inc",
+            },
+          ],
+        } satisfies Partial<ListOrganizationsQuery>);
       });
     });
   });

--- a/packages/query/src/r5/hooks/index.ts
+++ b/packages/query/src/r5/hooks/index.ts
@@ -8,6 +8,7 @@ export * from "./use-fhir-execute-mutation";
 export * from "./use-fhir-graph";
 export * from "./use-fhir-graphql";
 export * from "./use-fhir-graphql-mutation";
+export * from "./use-fhir-graphql-result";
 export * from "./use-fhir-history";
 export * from "./use-fhir-infinite-search";
 export * from "./use-fhir-patch-mutation";

--- a/packages/query/src/r5/hooks/use-fhir-graphql-mutation.tsx
+++ b/packages/query/src/r5/hooks/use-fhir-graphql-mutation.tsx
@@ -23,6 +23,11 @@ export interface UseFhirGraphQLMutationOptions<
     | undefined;
 }
 
+/**
+ * Execute a [$graphql mutation](https://hl7.org/fhir/resource-operation-graphql.html).
+ *
+ * The mutation is put on error if there are GraphQL errors in the response.
+ */
 export function useFhirGraphQLMutation<TResult = any>(
   query: string,
   operationName?: string | null | undefined,

--- a/packages/query/src/r5/hooks/use-fhir-graphql.tsx
+++ b/packages/query/src/r5/hooks/use-fhir-graphql.tsx
@@ -27,6 +27,12 @@ export interface UseFhirGraphQLOptions<TResult = any> {
 
 /**
  * Execute a [$graphql operation](https://hl7.org/fhir/resource-operation-graphql.html).
+ *
+ * This hook puts the query on error if there are GraphQL errors in the response.
+ * This make it easier to reason about, but do not support partial errors in GraphQL.
+ *
+ * Use the `useFhirGraphqlResult` hook to have access to the raw GraphQL response,
+ * including the `errors` and `extensions` field.
  */
 export function useFhirGraphQL<TResult = any>(
   query: string,

--- a/packages/query/src/r5/index.test.tsx
+++ b/packages/query/src/r5/index.test.tsx
@@ -32,6 +32,7 @@ import {
   useFhirExecuteMutation,
   useFhirGraphQL,
   useFhirGraphQLMutation,
+  useFhirGraphQLResult,
   useFhirHistory,
   useFhirInfiniteSearch,
   useFhirPatchMutation,
@@ -742,6 +743,59 @@ describe("hooks", () => {
             ],
           } satisfies Partial<ListOrganizationsQuery>);
         });
+      });
+    });
+  });
+
+  describe("GraphQLResult", () => {
+    it("execute a query as a string", async () => {
+      const { result } = renderHook(
+        () =>
+          useFhirGraphQLResult(
+            `{
+              Patient(id: "patient-id") {
+                resourceType
+                id
+                name {
+                  given
+                  family
+                }
+              }
+            }`,
+          ),
+        { wrapper },
+      );
+
+      await waitFor(() => {
+        expect(result.current.isSuccess).toBeTruthy();
+        expect(result.current.data?.data).toMatchObject({
+          Patient: {
+            resourceType: "Patient",
+            id: expect.stringMatching(/.+/),
+          },
+        });
+      });
+    });
+
+    it("execute a query as a document", async () => {
+      const { result } = renderHook(
+        () =>
+          useFhirGraphQLResult(ListOrganizationsDocument, {
+            name: "Acme, Inc",
+          }),
+        { wrapper },
+      );
+
+      await waitFor(() => {
+        expect(result.current.isSuccess).toBeTruthy();
+        expect(result.current.data?.data).toMatchObject({
+          OrganizationList: [
+            {
+              resourceType: "Organization",
+              name: "Acme, Inc",
+            },
+          ],
+        } satisfies Partial<ListOrganizationsQuery>);
       });
     });
   });


### PR DESCRIPTION
I went with a separate method and hook (called `graphqlResult` and `useFhirGraphqlResult` to expose GraphQL execution result.

I tried to merge it with the other through an option, but I couldn't find a solution that was both elegant and ergonomic to use :-(.

Curious to get your thoughts on this option.