### PR TITLE
Return a cloned resource in `<FhirInput type="resource" />`

### DIFF
--- a/.changeset/great-pens-lick.md
+++ b/.changeset/great-pens-lick.md
@@ -1,0 +1,5 @@
+---
+"@bonfhir/react": patch
+---
+
+Return a cloned resource in `<FhirInput type="resource" />`

--- a/packages/react/src/r4b/inputs/input-types/fhir-input-resource.tsx
+++ b/packages/react/src/r4b/inputs/input-types/fhir-input-resource.tsx
@@ -5,6 +5,7 @@ import {
   Reference,
   Resource,
   ResourceTypeOf,
+  cloneResource,
   id,
   reference,
 } from "@bonfhir/core/r4b";
@@ -85,7 +86,7 @@ export function FhirInputResource<
       }
 
       if (props.type === "Resource") {
-        props.onChange?.(value as any);
+        props.onChange?.(cloneResource(value as any));
       }
     },
     data: searchQuery.data?.searchMatch() ?? [],

--- a/packages/react/src/r5/inputs/input-types/fhir-input-resource.tsx
+++ b/packages/react/src/r5/inputs/input-types/fhir-input-resource.tsx
@@ -5,6 +5,7 @@ import {
   Reference,
   Resource,
   ResourceTypeOf,
+  cloneResource,
   id,
   reference,
 } from "@bonfhir/core/r5";
@@ -85,7 +86,7 @@ export function FhirInputResource<
       }
 
       if (props.type === "Resource") {
-        props.onChange?.(value as any);
+        props.onChange?.(cloneResource(value as any));
       }
     },
     data: searchQuery.data?.searchMatch() ?? [],


### PR DESCRIPTION
This will avoid problems if the consuming code changes the resource (so impact the underlying model).

This also solve an issue we had in storybook.