### PR TITLE
Fix-mantine-migration-bugs

### DIFF
--- a/.changeset/spicy-cows-eat.md
+++ b/.changeset/spicy-cows-eat.md
@@ -1,0 +1,5 @@
+---
+"@bonfhir/mantine": patch
+---
+
+Fix `FhirTable` sub-components to fit mantine v7

--- a/.changeset/tender-snails-hunt.md
+++ b/.changeset/tender-snails-hunt.md
@@ -1,0 +1,6 @@
+---
+"@bonfhir/cli": patch
+"create-bonfhir": patch
+---
+
+Add missing css imports since mantine v7 migration

--- a/apps/sample-ehr/src/pages/_app.tsx
+++ b/apps/sample-ehr/src/pages/_app.tsx
@@ -14,6 +14,8 @@ import {
   createTheme,
 } from "@mantine/core";
 import "@mantine/core/styles.css";
+import "@mantine/dates/styles.css";
+import "@mantine/tiptap/styles.css";
 import { ReactQueryDevtools } from "@tanstack/react-query-devtools";
 import { SessionProvider, signIn, signOut, useSession } from "next-auth/react";
 import { AppProps } from "next/app";

--- a/docs/storybook/.storybook/preview.tsx
+++ b/docs/storybook/.storybook/preview.tsx
@@ -3,6 +3,8 @@ import { FhirQueryProvider } from "@bonfhir/query/r5";
 import { FhirUIProvider } from "@bonfhir/react/r5";
 import { MantineProvider } from "@mantine/core";
 import "@mantine/core/styles.css";
+import "@mantine/dates/styles.css";
+import "@mantine/tiptap/styles.css";
 import type { Preview } from "@storybook/react";
 import { mockClient } from "./mock-fhir-client";
 

--- a/packages/cli/src/templates/next.ts
+++ b/packages/cli/src/templates/next.ts
@@ -281,6 +281,8 @@ import {
   createTheme,
 } from "@mantine/core";
 import "@mantine/core/styles.css";
+import "@mantine/dates/styles.css";
+import "@mantine/tiptap/styles.css";
 import { ReactQueryDevtools } from "@tanstack/react-query-devtools";
 import { SessionProvider, signIn, signOut, useSession } from "next-auth/react";
 import { AppProps } from "next/app";

--- a/packages/cli/src/templates/vite.ts
+++ b/packages/cli/src/templates/vite.ts
@@ -358,6 +358,8 @@ ReactDOM.createRoot(document.getElementById("root")!).render(
 `;
 
 const APP_CONTENT = `import "@mantine/core/styles.css";
+import "@mantine/dates/styles.css";
+import "@mantine/tiptap/styles.css";
 import { FetchFhirClient } from "@bonfhir/core/r4b";
 import { FhirQueryProvider } from "@bonfhir/query/r4b";
 import { MantineRenderer } from "@bonfhir/mantine/r4b";

--- a/packages/mantine/src/r4b/data-display/fhir-table.tsx
+++ b/packages/mantine/src/r4b/data-display/fhir-table.tsx
@@ -5,18 +5,23 @@ import {
   FhirTableRendererProps,
   useFhirUIContext,
 } from "@bonfhir/react/r4b";
-import { Group, Table, TableProps, UnstyledButton } from "@mantine/core";
+import {
+  Group,
+  Table,
+  TableProps,
+  TableTbodyProps,
+  TableTdProps,
+  TableThProps,
+  TableTheadProps,
+  TableTrProps,
+  UnstyledButton,
+} from "@mantine/core";
 import {
   IconChevronDown,
   IconChevronUp,
   IconSelector,
 } from "@tabler/icons-react";
-import {
-  DetailedHTMLProps,
-  HTMLAttributes,
-  ReactElement,
-  createElement,
-} from "react";
+import { ReactElement, createElement } from "react";
 
 export function MantineFhirTable(
   props: FhirTableRendererProps<MantineFhirTableProps>,
@@ -29,13 +34,13 @@ export function MantineFhirTable(
       style={props.style}
       {...props.rendererProps?.table}
     >
-      <thead {...props.rendererProps?.thead}>
+      <Table.Thead {...props.rendererProps?.thead}>
         {props.rendererProps?.theadPrefix
           ? createElement(props.rendererProps.theadPrefix)
           : null}
-        <tr>
+        <Table.Tr>
           {props.columns.map((column) => (
-            <th
+            <Table.Th
               key={column.key}
               {...propsOrFunction(props.rendererProps?.th, column)}
             >
@@ -47,14 +52,14 @@ export function MantineFhirTable(
                   onSortChange: props.onSortChange,
                 },
               )}
-            </th>
+            </Table.Th>
           ))}
-        </tr>
-      </thead>
+        </Table.Tr>
+      </Table.Thead>
       {Boolean(props.rows) && (
-        <tbody {...props.rendererProps?.tbody}>
+        <Table.Tbody {...props.rendererProps?.tbody}>
           {props.rows?.map((row, index) => (
-            <tr
+            <Table.Tr
               key={index}
               onClick={() => {
                 props.onRowClick?.(row as any, index);
@@ -79,16 +84,16 @@ export function MantineFhirTable(
               {...propsOrFunction(props.rendererProps?.tr, row)}
             >
               {props.columns.map((column) => (
-                <td
+                <Table.Td
                   key={column.key}
                   {...propsOrFunction(props.rendererProps?.td, column, row)}
                 >
                   {column.render(row as any, index)}
-                </td>
+                </Table.Td>
               ))}
-            </tr>
+            </Table.Tr>
           ))}
-        </tbody>
+        </Table.Tbody>
       )}
     </Table>
   );
@@ -159,60 +164,19 @@ function propsOrFunction<TProps extends object>(
 
 export interface MantineFhirTableProps {
   table?: TableProps | null | undefined;
-  thead?:
-    | DetailedHTMLProps<
-        HTMLAttributes<HTMLTableSectionElement>,
-        HTMLTableSectionElement
-      >
-    | null
-    | undefined;
+  thead?: TableTheadProps | null | undefined;
   theadPrefix?: () => ReactElement;
   headerCell?: (props: MantineFhirTableHeaderProps) => ReactElement;
-  tbody?:
-    | DetailedHTMLProps<
-        HTMLAttributes<HTMLTableSectionElement>,
-        HTMLTableSectionElement
-      >
-    | null
-    | undefined;
+  tbody?: TableTbodyProps | null | undefined;
   th?:
-    | DetailedHTMLProps<
-        HTMLAttributes<HTMLTableCellElement>,
-        HTMLTableCellElement
-      >
-    | ((
-        column: FhirTableColumn<any>,
-      ) => DetailedHTMLProps<
-        HTMLAttributes<HTMLTableCellElement>,
-        HTMLTableCellElement
-      >)
+    | TableThProps
+    | ((column: FhirTableColumn<any>) => TableThProps)
     | null
     | undefined;
-  tr?:
-    | DetailedHTMLProps<
-        HTMLAttributes<HTMLTableRowElement>,
-        HTMLTableRowElement
-      >
-    | ((
-        row: any,
-      ) => DetailedHTMLProps<
-        HTMLAttributes<HTMLTableRowElement>,
-        HTMLTableRowElement
-      >)
-    | null
-    | undefined;
+  tr?: TableTrProps | ((row: any) => TableTrProps) | null | undefined;
   td?:
-    | DetailedHTMLProps<
-        HTMLAttributes<HTMLTableCellElement>,
-        HTMLTableCellElement
-      >
-    | ((
-        column: FhirTableColumn<any>,
-        row: any,
-      ) => DetailedHTMLProps<
-        HTMLAttributes<HTMLTableCellElement>,
-        HTMLTableCellElement
-      >)
+    | TableTdProps
+    | ((column: FhirTableColumn<any>, row: any) => TableTdProps)
     | null
     | undefined;
 }

--- a/packages/mantine/src/r5/data-display/fhir-table.tsx
+++ b/packages/mantine/src/r5/data-display/fhir-table.tsx
@@ -5,18 +5,23 @@ import {
   FhirTableRendererProps,
   useFhirUIContext,
 } from "@bonfhir/react/r5";
-import { Group, Table, TableProps, UnstyledButton } from "@mantine/core";
+import {
+  Group,
+  Table,
+  TableProps,
+  TableTbodyProps,
+  TableTdProps,
+  TableThProps,
+  TableTheadProps,
+  TableTrProps,
+  UnstyledButton,
+} from "@mantine/core";
 import {
   IconChevronDown,
   IconChevronUp,
   IconSelector,
 } from "@tabler/icons-react";
-import {
-  DetailedHTMLProps,
-  HTMLAttributes,
-  ReactElement,
-  createElement,
-} from "react";
+import { ReactElement, createElement } from "react";
 
 export function MantineFhirTable(
   props: FhirTableRendererProps<MantineFhirTableProps>,
@@ -29,13 +34,13 @@ export function MantineFhirTable(
       style={props.style}
       {...props.rendererProps?.table}
     >
-      <thead {...props.rendererProps?.thead}>
+      <Table.Thead {...props.rendererProps?.thead}>
         {props.rendererProps?.theadPrefix
           ? createElement(props.rendererProps.theadPrefix)
           : null}
-        <tr>
+        <Table.Tr>
           {props.columns.map((column) => (
-            <th
+            <Table.Th
               key={column.key}
               {...propsOrFunction(props.rendererProps?.th, column)}
             >
@@ -47,14 +52,14 @@ export function MantineFhirTable(
                   onSortChange: props.onSortChange,
                 },
               )}
-            </th>
+            </Table.Th>
           ))}
-        </tr>
-      </thead>
+        </Table.Tr>
+      </Table.Thead>
       {Boolean(props.rows) && (
-        <tbody {...props.rendererProps?.tbody}>
+        <Table.Tbody {...props.rendererProps?.tbody}>
           {props.rows?.map((row, index) => (
-            <tr
+            <Table.Tr
               key={index}
               onClick={() => {
                 props.onRowClick?.(row as any, index);
@@ -79,16 +84,16 @@ export function MantineFhirTable(
               {...propsOrFunction(props.rendererProps?.tr, row)}
             >
               {props.columns.map((column) => (
-                <td
+                <Table.Td
                   key={column.key}
                   {...propsOrFunction(props.rendererProps?.td, column, row)}
                 >
                   {column.render(row as any, index)}
-                </td>
+                </Table.Td>
               ))}
-            </tr>
+            </Table.Tr>
           ))}
-        </tbody>
+        </Table.Tbody>
       )}
     </Table>
   );
@@ -159,60 +164,19 @@ function propsOrFunction<TProps extends object>(
 
 export interface MantineFhirTableProps {
   table?: TableProps | null | undefined;
-  thead?:
-    | DetailedHTMLProps<
-        HTMLAttributes<HTMLTableSectionElement>,
-        HTMLTableSectionElement
-      >
-    | null
-    | undefined;
+  thead?: TableTheadProps | null | undefined;
   theadPrefix?: () => ReactElement;
   headerCell?: (props: MantineFhirTableHeaderProps) => ReactElement;
-  tbody?:
-    | DetailedHTMLProps<
-        HTMLAttributes<HTMLTableSectionElement>,
-        HTMLTableSectionElement
-      >
-    | null
-    | undefined;
+  tbody?: TableTbodyProps | null | undefined;
   th?:
-    | DetailedHTMLProps<
-        HTMLAttributes<HTMLTableCellElement>,
-        HTMLTableCellElement
-      >
-    | ((
-        column: FhirTableColumn<any>,
-      ) => DetailedHTMLProps<
-        HTMLAttributes<HTMLTableCellElement>,
-        HTMLTableCellElement
-      >)
+    | TableThProps
+    | ((column: FhirTableColumn<any>) => TableThProps)
     | null
     | undefined;
-  tr?:
-    | DetailedHTMLProps<
-        HTMLAttributes<HTMLTableRowElement>,
-        HTMLTableRowElement
-      >
-    | ((
-        row: any,
-      ) => DetailedHTMLProps<
-        HTMLAttributes<HTMLTableRowElement>,
-        HTMLTableRowElement
-      >)
-    | null
-    | undefined;
+  tr?: TableTrProps | ((row: any) => TableTrProps) | null | undefined;
   td?:
-    | DetailedHTMLProps<
-        HTMLAttributes<HTMLTableCellElement>,
-        HTMLTableCellElement
-      >
-    | ((
-        column: FhirTableColumn<any>,
-        row: any,
-      ) => DetailedHTMLProps<
-        HTMLAttributes<HTMLTableCellElement>,
-        HTMLTableCellElement
-      >)
+    | TableTdProps
+    | ((column: FhirTableColumn<any>, row: any) => TableTdProps)
     | null
     | undefined;
 }


### PR DESCRIPTION
This PR fixes some UI bugs related to the mantine v7 migration:
 - the mantine table sub-components are different, which resulted in styling not being applied properly
 - missing CSS import to fix issues with markdown editor and date/time dropdowns