### PR TITLE
Fix #118 - Handling of Choice of DataTypes - add the `choice` formatter + `choiceOfDataTypes` helper

### DIFF
--- a/.changeset/fifty-rockets-agree.md
+++ b/.changeset/fifty-rockets-agree.md
@@ -1,0 +1,6 @@
+---
+"@bonfhir/react": minor
+"@bonfhir/core": minor
+---
+
+Fix #118 - Handling of Choice of DataTypes - add the `choice` formatter + `choiceOfDataTypes` helper

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -71,6 +71,7 @@
     "tanstack",
     "tiptap",
     "UCUM",
+    "Uncapitalize",
     "vread"
   ],
   "eslint.workingDirectories": ["apps/*", "packages/*"],

--- a/apps/sample-ehr/src/app/patients/[patientId]/conditions/page.tsx
+++ b/apps/sample-ehr/src/app/patients/[patientId]/conditions/page.tsx
@@ -86,12 +86,13 @@ export default function Conditions() {
                 },
                 {
                   key: "onset-date",
-                  title: "Onset Date",
+                  title: "Onset",
                   sortable: true,
                   render: (condition) => (
                     <FhirValue
-                      type="dateTime"
-                      value={condition.onsetDateTime}
+                      type="choice"
+                      value={condition}
+                      options={{ prefix: "onset" }}
                     />
                   ),
                 },

--- a/packages/core/src/r4b/formatters.ts
+++ b/packages/core/src/r4b/formatters.ts
@@ -6,6 +6,7 @@ import {
   ageFormatter,
   booleanFormatter,
   canonicalFormatter,
+  choiceFormatter,
   codeFormatter,
   codeableConceptFormatter,
   codingFormatter,
@@ -38,7 +39,7 @@ import {
   uriFormatter,
   urlFormatter,
   uuidFormatter,
-} from "./value-formatters/index";
+} from "./value-formatters";
 
 /**
  * A value formatter is a function that takes a value and returns a string.
@@ -152,6 +153,7 @@ export class Formatter {
       .register(ageFormatter)
       .register(booleanFormatter)
       .register(canonicalFormatter)
+      .register(choiceFormatter)
       .register(codeFormatter)
       .register(codeableConceptFormatter)
       .register(codingFormatter)
@@ -312,6 +314,7 @@ export type DefaultFormatterParameters =
   | ValueFormatterParameters<typeof ageFormatter>
   | ValueFormatterParameters<typeof booleanFormatter>
   | ValueFormatterParameters<typeof canonicalFormatter>
+  | ValueFormatterParameters<typeof choiceFormatter>
   | ValueFormatterParameters<typeof codeFormatter>
   | ValueFormatterParameters<typeof codeableConceptFormatter>
   | ValueFormatterParameters<typeof codingFormatter>

--- a/packages/core/src/r4b/lang-utils.test.ts
+++ b/packages/core/src/r4b/lang-utils.test.ts
@@ -4,6 +4,7 @@ import { AnyResourceType, Reference, Resource } from "./fhir-types.codegen";
 import {
   asArray,
   asResource,
+  choiceOfDataTypes,
   cleanFhirValues,
   findReference,
   findReferences,
@@ -169,6 +170,43 @@ describe("lang-utils", () => {
       [AnyResourceType, Reference[] | null | undefined, unknown]
     >)("%p == %p", (type, value, expected) => {
       expect(findReferences(value, type)).toEqual(expected);
+    });
+  });
+
+  describe("choiceOfDataTypes", () => {
+    it("return undefined when no value", () => {
+      const condition = build("Condition", {
+        clinicalStatus: { text: "unknown" },
+        subject: {},
+      });
+
+      const result = choiceOfDataTypes(condition, "onset", {});
+      expect(result).toBeUndefined();
+    });
+
+    it("return undefined when no options", () => {
+      const condition = build("Condition", {
+        clinicalStatus: { text: "unknown" },
+        subject: {},
+        onsetDateTime: "2020-01-01",
+      });
+
+      const result = choiceOfDataTypes(condition, "onset", {});
+      expect(result).toBeUndefined();
+    });
+
+    it("return value", () => {
+      const condition = build("Condition", {
+        clinicalStatus: { text: "unknown" },
+        subject: {},
+        onsetDateTime: "2020-01-01",
+      });
+
+      const result = choiceOfDataTypes(condition, "onset", {
+        dateTime: (value: string) => value + "dateTime",
+        string: (value: string) => value + "string",
+      });
+      expect(result).toEqual("2020-01-01dateTime");
     });
   });
 });

--- a/packages/core/src/r4b/value-formatters/choice.test.ts
+++ b/packages/core/src/r4b/value-formatters/choice.test.ts
@@ -1,0 +1,41 @@
+import { Condition } from "../fhir-types.codegen";
+import { Formatter } from "../formatters";
+import { ChoiceFormatterOptions, choiceFormatter } from "./choice";
+import { dateTimeFormatter } from "./date-time";
+import { periodFormatter } from "./period";
+import { stringFormatter } from "./string";
+
+describe("choice", () => {
+  const formatter = new Formatter()
+    .register(choiceFormatter)
+    .register(stringFormatter)
+    .register(dateTimeFormatter)
+    .register(periodFormatter);
+
+  it.each([
+    [{}, { prefix: "onset" }, ""],
+    [{ onsetString: "some value" }, { prefix: "onset" }, "some value"],
+    [{ onsetDateTime: "2021-02-03" }, { prefix: "onset" }, "2/3/2021"],
+    [
+      { onsetDateTime: "2021-02-03" },
+      { prefix: "onset", options: { dateTime: { dateStyle: "full" } } },
+      "Wednesday, February 3, 2021",
+    ],
+    [
+      { onsetPeriod: { start: "2020-01-01", end: "2020-01-12" } },
+      { prefix: "onset" },
+      "1/1/2020 - 1/12/2020",
+    ],
+  ] satisfies Array<[Partial<Condition>, ChoiceFormatterOptions, string]>)(
+    "format %p %p => %p",
+    (value, options, expected) => {
+      expect(formatter.format("choice", value, options)).toEqual(expected);
+    },
+  );
+
+  it("throws when missing prefix", () => {
+    expect(() => formatter.format("choice", {} as never, {})).toThrow(
+      "Missing prefix - cannot format choice",
+    );
+  });
+});

--- a/packages/core/src/r4b/value-formatters/choice.ts
+++ b/packages/core/src/r4b/value-formatters/choice.ts
@@ -1,0 +1,70 @@
+import { CommonFormatterOptions, ValueFormatter } from "../formatters";
+
+/**
+ * Handles Choice of Datatypes attributes
+ * Invokes the appropriate formatter based on the type of the value.
+ *
+ * @see https://hl7.org/fhir/formats.html#choice
+ */
+export interface ChoiceFormatterOptions {
+  /**
+   * The common prefix (constant) for all the choices.
+   */
+  prefix: string;
+
+  /**
+   * Formatter-specific options, passed to the formatter when formatting the value.
+   *
+   * @example
+   *
+   * { dateTime: { dateStyle: "MM/DD/YYYY" } }
+   */
+  options?: Record<string, unknown>;
+}
+
+export const choiceFormatter: ValueFormatter<
+  "choice",
+  object | null | undefined,
+  ChoiceFormatterOptions
+> = {
+  type: "choice",
+  format: (value, options, formatterOptions) => {
+    if (!options?.prefix) {
+      throw new Error("Missing prefix - cannot format choice");
+    }
+
+    if (!value) {
+      return "";
+    }
+
+    for (const [key, choice] of Object.entries(value).filter(([k]) =>
+      k.startsWith(options.prefix),
+    )) {
+      // eslint-disable-next-line unicorn/no-null
+      if (choice != null) {
+        const suffix = key.slice(options.prefix.length);
+        const suffixCapitalized =
+          suffix.charAt(0).toUpperCase() + suffix.slice(1);
+        if (formatterOptions.formatter.canFormat(suffixCapitalized)) {
+          return formatterOptions.formatter.format(
+            suffixCapitalized,
+            choice as never,
+            options?.options?.[suffixCapitalized] as CommonFormatterOptions,
+          );
+        }
+
+        const suffixUncapitalized =
+          suffix.charAt(0).toLowerCase() + suffix.slice(1);
+        if (formatterOptions.formatter.canFormat(suffixUncapitalized)) {
+          return formatterOptions.formatter.format(
+            suffixUncapitalized,
+            choice as never,
+            options?.options?.[suffixUncapitalized] as CommonFormatterOptions,
+          );
+        }
+      }
+    }
+
+    return "";
+  },
+};

--- a/packages/core/src/r4b/value-formatters/index.ts
+++ b/packages/core/src/r4b/value-formatters/index.ts
@@ -2,6 +2,7 @@ export * from "./address";
 export * from "./age";
 export * from "./boolean";
 export * from "./canonical";
+export * from "./choice";
 export * from "./code";
 export * from "./codeable-concept";
 export * from "./coding";

--- a/packages/core/src/r5/formatters.ts
+++ b/packages/core/src/r5/formatters.ts
@@ -6,6 +6,7 @@ import {
   ageFormatter,
   booleanFormatter,
   canonicalFormatter,
+  choiceFormatter,
   codeFormatter,
   codeableConceptFormatter,
   codingFormatter,
@@ -39,7 +40,7 @@ import {
   uriFormatter,
   urlFormatter,
   uuidFormatter,
-} from "./value-formatters/index";
+} from "./value-formatters";
 
 /**
  * A value formatter is a function that takes a value and returns a string.
@@ -154,6 +155,7 @@ export class Formatter {
         .register(ageFormatter)
         .register(booleanFormatter)
         .register(canonicalFormatter)
+        .register(choiceFormatter)
         .register(codeFormatter)
         .register(codeableConceptFormatter)
         .register(codingFormatter)
@@ -318,6 +320,7 @@ export type DefaultFormatterParameters =
   | ValueFormatterParameters<typeof ageFormatter>
   | ValueFormatterParameters<typeof booleanFormatter>
   | ValueFormatterParameters<typeof canonicalFormatter>
+  | ValueFormatterParameters<typeof choiceFormatter>
   | ValueFormatterParameters<typeof codeFormatter>
   | ValueFormatterParameters<typeof codeableConceptFormatter>
   | ValueFormatterParameters<typeof codingFormatter>

--- a/packages/core/src/r5/lang-utils.test.ts
+++ b/packages/core/src/r5/lang-utils.test.ts
@@ -4,6 +4,7 @@ import { AnyResourceType, Reference, Resource } from "./fhir-types.codegen";
 import {
   asArray,
   asResource,
+  choiceOfDataTypes,
   cleanFhirValues,
   findReference,
   findReferences,
@@ -169,6 +170,43 @@ describe("lang-utils", () => {
       [AnyResourceType, Reference[] | null | undefined, unknown]
     >)("%p == %p", (type, value, expected) => {
       expect(findReferences(value, type)).toEqual(expected);
+    });
+  });
+
+  describe("choiceOfDataTypes", () => {
+    it("return undefined when no value", () => {
+      const condition = build("Condition", {
+        clinicalStatus: { text: "unknown" },
+        subject: {},
+      });
+
+      const result = choiceOfDataTypes(condition, "onset", {});
+      expect(result).toBeUndefined();
+    });
+
+    it("return undefined when no options", () => {
+      const condition = build("Condition", {
+        clinicalStatus: { text: "unknown" },
+        subject: {},
+        onsetDateTime: "2020-01-01",
+      });
+
+      const result = choiceOfDataTypes(condition, "onset", {});
+      expect(result).toBeUndefined();
+    });
+
+    it("return value", () => {
+      const condition = build("Condition", {
+        clinicalStatus: { text: "unknown" },
+        subject: {},
+        onsetDateTime: "2020-01-01",
+      });
+
+      const result = choiceOfDataTypes(condition, "onset", {
+        dateTime: (value: string) => value + "dateTime",
+        string: (value: string) => value + "string",
+      });
+      expect(result).toEqual("2020-01-01dateTime");
     });
   });
 });

--- a/packages/core/src/r5/value-formatters/choice.test.ts
+++ b/packages/core/src/r5/value-formatters/choice.test.ts
@@ -1,0 +1,41 @@
+import { Condition } from "../fhir-types.codegen";
+import { Formatter } from "../formatters";
+import { ChoiceFormatterOptions, choiceFormatter } from "./choice";
+import { dateTimeFormatter } from "./date-time";
+import { periodFormatter } from "./period";
+import { stringFormatter } from "./string";
+
+describe("choice", () => {
+  const formatter = new Formatter()
+    .register(choiceFormatter)
+    .register(stringFormatter)
+    .register(dateTimeFormatter)
+    .register(periodFormatter);
+
+  it.each([
+    [{}, { prefix: "onset" }, ""],
+    [{ onsetString: "some value" }, { prefix: "onset" }, "some value"],
+    [{ onsetDateTime: "2021-02-03" }, { prefix: "onset" }, "2/3/2021"],
+    [
+      { onsetDateTime: "2021-02-03" },
+      { prefix: "onset", options: { dateTime: { dateStyle: "full" } } },
+      "Wednesday, February 3, 2021",
+    ],
+    [
+      { onsetPeriod: { start: "2020-01-01", end: "2020-01-12" } },
+      { prefix: "onset" },
+      "1/1/2020 - 1/12/2020",
+    ],
+  ] satisfies Array<[Partial<Condition>, ChoiceFormatterOptions, string]>)(
+    "format %p %p => %p",
+    (value, options, expected) => {
+      expect(formatter.format("choice", value, options)).toEqual(expected);
+    },
+  );
+
+  it("throws when missing prefix", () => {
+    expect(() => formatter.format("choice", {} as never, {})).toThrow(
+      "Missing prefix - cannot format choice",
+    );
+  });
+});

--- a/packages/core/src/r5/value-formatters/choice.ts
+++ b/packages/core/src/r5/value-formatters/choice.ts
@@ -1,0 +1,70 @@
+import { CommonFormatterOptions, ValueFormatter } from "../formatters";
+
+/**
+ * Handles Choice of Datatypes attributes
+ * Invokes the appropriate formatter based on the type of the value.
+ *
+ * @see https://hl7.org/fhir/formats.html#choice
+ */
+export interface ChoiceFormatterOptions {
+  /**
+   * The common prefix (constant) for all the choices.
+   */
+  prefix: string;
+
+  /**
+   * Formatter-specific options, passed to the formatter when formatting the value.
+   *
+   * @example
+   *
+   * { dateTime: { dateStyle: "MM/DD/YYYY" } }
+   */
+  options?: Record<string, unknown>;
+}
+
+export const choiceFormatter: ValueFormatter<
+  "choice",
+  object | null | undefined,
+  ChoiceFormatterOptions
+> = {
+  type: "choice",
+  format: (value, options, formatterOptions) => {
+    if (!options?.prefix) {
+      throw new Error("Missing prefix - cannot format choice");
+    }
+
+    if (!value) {
+      return "";
+    }
+
+    for (const [key, choice] of Object.entries(value).filter(([k]) =>
+      k.startsWith(options.prefix),
+    )) {
+      // eslint-disable-next-line unicorn/no-null
+      if (choice != null) {
+        const suffix = key.slice(options.prefix.length);
+        const suffixCapitalized =
+          suffix.charAt(0).toUpperCase() + suffix.slice(1);
+        if (formatterOptions.formatter.canFormat(suffixCapitalized)) {
+          return formatterOptions.formatter.format(
+            suffixCapitalized,
+            choice as never,
+            options?.options?.[suffixCapitalized] as CommonFormatterOptions,
+          );
+        }
+
+        const suffixUncapitalized =
+          suffix.charAt(0).toLowerCase() + suffix.slice(1);
+        if (formatterOptions.formatter.canFormat(suffixUncapitalized)) {
+          return formatterOptions.formatter.format(
+            suffixUncapitalized,
+            choice as never,
+            options?.options?.[suffixUncapitalized] as CommonFormatterOptions,
+          );
+        }
+      }
+    }
+
+    return "";
+  },
+};

--- a/packages/core/src/r5/value-formatters/index.ts
+++ b/packages/core/src/r5/value-formatters/index.ts
@@ -2,6 +2,7 @@ export * from "./address";
 export * from "./age";
 export * from "./boolean";
 export * from "./canonical";
+export * from "./choice";
 export * from "./code";
 export * from "./codeable-concept";
 export * from "./coding";

--- a/packages/react/src/r4b/data-display/fhir-value.tsx
+++ b/packages/react/src/r4b/data-display/fhir-value.tsx
@@ -35,6 +35,7 @@ export type DefaultFormatterParametersProps =
   | ValueFormatterParametersAsProps<typeof valueFormatters.ageFormatter>
   | ValueFormatterParametersAsProps<typeof valueFormatters.booleanFormatter>
   | ValueFormatterParametersAsProps<typeof valueFormatters.canonicalFormatter>
+  | ValueFormatterParametersAsProps<typeof valueFormatters.choiceFormatter>
   | ValueFormatterParametersAsProps<typeof valueFormatters.codeFormatter>
   | ValueFormatterParametersAsProps<
       typeof valueFormatters.codeableConceptFormatter

--- a/packages/react/src/r5/data-display/fhir-value.tsx
+++ b/packages/react/src/r5/data-display/fhir-value.tsx
@@ -35,6 +35,7 @@ export type DefaultFormatterParametersProps =
   | ValueFormatterParametersAsProps<typeof valueFormatters.ageFormatter>
   | ValueFormatterParametersAsProps<typeof valueFormatters.booleanFormatter>
   | ValueFormatterParametersAsProps<typeof valueFormatters.canonicalFormatter>
+  | ValueFormatterParametersAsProps<typeof valueFormatters.choiceFormatter>
   | ValueFormatterParametersAsProps<typeof valueFormatters.codeFormatter>
   | ValueFormatterParametersAsProps<
       typeof valueFormatters.codeableConceptFormatter


### PR DESCRIPTION
Fix #118.

Code examples:

```typescript
const result = choiceOfDataTypes(condition, "onset", {
  dateTime: (value: string) => value + " as dateTime",
  string: (value: string) => value + " as string",
  Period: (value: Period) => value + " as Period",
});
```

```typescript
formatter.format("choice", condition, { prefix: "onset" });
```

```tsx
<FhirValue type="choice" value={condition} options={{ prefix: "onset", options: { dateTime: { dateStyle: "full" } } }} />
```