### PR TITLE
Fix BUG: FhirInput Reference type for practitioner does not search on change #113

### DIFF
--- a/.changeset/khaki-beans-grab.md
+++ b/.changeset/khaki-beans-grab.md
@@ -1,0 +1,6 @@
+---
+"@bonfhir/mantine": patch
+"@bonfhir/react": patch
+---
+
+Fix #113 - search can now be a function, defaults to `_text=`, display query errors, and support form reset

--- a/apps/sample-ehr/src/app/patients/[patientId]/edit/page.tsx
+++ b/apps/sample-ehr/src/app/patients/[patientId]/edit/page.tsx
@@ -98,6 +98,14 @@ export default function EditPatient() {
                 );
               }}
             </FhirInputArray>
+            <Group>
+              <FhirInput
+                type="Reference"
+                label="Managing Organization"
+                resourceType="Organization"
+                {...form.getInputProps("managingOrganization")}
+              />
+            </Group>
             <SaveChangesButtons save={{ loading: form.mutation.isLoading }} />
           </Stack>
         </form>

--- a/apps/sample-ehr/src/app/patients/page.tsx
+++ b/apps/sample-ehr/src/app/patients/page.tsx
@@ -43,6 +43,7 @@ export default function Patients() {
         managingOrganization: search?.managingOrganization ?? "",
       });
     },
+    defaultSort: "-_lastUpdated",
   });
 
   const patientsQuery = useFhirSearch(
@@ -83,7 +84,7 @@ export default function Patients() {
                 resourceType="Practitioner"
                 label="Provider"
                 style={{ width: "100%" }}
-                search={(query) => `name=${query}`}
+                search={(query) => (search) => search.name(query)}
                 {...form.getInputProps("practitioner")}
               />
               <FhirInput
@@ -91,6 +92,7 @@ export default function Patients() {
                 resourceType="Organization"
                 label="Clinic"
                 style={{ width: "100%" }}
+                search={(query) => (search) => search.name(query)}
                 {...form.getInputProps("managingOrganization")}
               />
               <Group grow preventGrowOverflow={false} wrap="nowrap">
@@ -168,6 +170,18 @@ export default function Patients() {
                     <FhirValue
                       type="string"
                       value={patient.managingOrganization?.display}
+                    />
+                  ),
+                },
+                {
+                  key: "_lastUpdated",
+                  title: "Last Updated",
+                  sortable: true,
+                  render: (patient) => (
+                    <FhirValue
+                      type="instant"
+                      value={patient.meta.lastUpdated}
+                      options={{ dateStyle: "relative" }}
                     />
                   ),
                 },

--- a/packages/mantine/src/r5/inputs/input-types/fhir-input-resource.tsx
+++ b/packages/mantine/src/r5/inputs/input-types/fhir-input-resource.tsx
@@ -1,7 +1,8 @@
 import { Resource } from "@bonfhir/core/r5";
-import { FhirInputResourceRendererProps } from "@bonfhir/react/r5";
+import { FhirError, FhirInputResourceRendererProps } from "@bonfhir/react/r5";
 import { Select, SelectProps } from "@mantine/core";
-import { ReactElement } from "react";
+import { usePrevious } from "@mantine/hooks";
+import { ReactElement, useEffect, useState } from "react";
 
 export function MantineFhirInputResource(
   props: FhirInputResourceRendererProps<MantineFhirInputResourceProps>,
@@ -13,6 +14,20 @@ export function MantineFhirInputResource(
       resource,
     }),
   );
+
+  // This is to track a reset event and reset the search as well.
+  const previousValue = usePrevious(props.value);
+  const [searchValue, setSearchValue] = useState("");
+
+  useEffect(() => {
+    if (!props.value && previousValue) {
+      setSearchValue("");
+    }
+  }, [props.value]);
+
+  if (props.error) {
+    return <FhirError error={props.error} />;
+  }
 
   return (
     <Select
@@ -28,25 +43,12 @@ export function MantineFhirInputResource(
       nothingFoundMessage="No results"
       clearable={!props.required}
       data={data}
-      //TODO itemComponent does not seem to exist in Mantine v7
-      // itemComponent={forwardRef<
-      //   HTMLDivElement,
-      //   MantineFhirInputResourceItemProps
-      // >(({ value: _, label: __, resource, ...others }, ref) => {
-      //   if (!resource) return null;
-      //   const rendered = props.display(resource);
-      //   return (
-      //     <div ref={ref} {...others}>
-      //       {typeof rendered === "string" ? <Text>{rendered}</Text> : rendered}
-      //     </div>
-      //   );
-      // })}
-      onSearchChange={props.onSearch}
-      value={
-        props.value
-          ? `${props.value.resourceType}/${props.value.id}`
-          : undefined
-      }
+      onSearchChange={(value) => {
+        setSearchValue(value);
+        props.onSearch(value);
+      }}
+      value={props.value ? `${props.value.resourceType}/${props.value.id}` : ""}
+      searchValue={searchValue}
       onChange={(value) => {
         const resource = value
           ? data.find(

--- a/packages/react/src/r4b/inputs/input-types/fhir-input-resource.tsx
+++ b/packages/react/src/r4b/inputs/input-types/fhir-input-resource.tsx
@@ -2,11 +2,13 @@ import {
   AnyResourceType,
   ExtractResource,
   FhirClientSearchParameters,
+  FhirSearchBuilder,
   Reference,
   Resource,
   ResourceTypeOf,
   cloneResource,
   id,
+  normalizeSearchParameters,
   reference,
 } from "@bonfhir/core/r4b";
 import { useFhirRead, useFhirSearch } from "@bonfhir/query/r4b";
@@ -71,9 +73,15 @@ export function FhirInputResource<
     value: valueQuery.data || undefined,
     onSearch: (query: string) => {
       if (props.search) {
-        setSearchParams(props.search(query));
+        const normalizedSearch = normalizeSearchParameters(
+          props.resourceType,
+          props.search(query),
+        );
+        setSearchParams(normalizedSearch ?? "");
       } else {
-        setSearchParams("");
+        setSearchParams(
+          new FhirSearchBuilder().stringParam("_text", query).href,
+        );
       }
     },
     onChange: (value: Resource | undefined) => {
@@ -95,6 +103,7 @@ export function FhirInputResource<
       ((resource: Resource) =>
         reference(resource as any)?.display ??
         `${resource.resourceType}/${resource.id}`),
+    error: valueQuery.error ?? searchQuery.error,
   });
 }
 
@@ -105,6 +114,7 @@ export type FhirInputResourceRendererProps<TRendererProps = any> =
     onSearch: (query: string) => void;
     data: Resource[];
     display: (resource: Resource) => string;
+    error: unknown | undefined;
   };
 
 export type FhirInputResourceRenderer = (

--- a/packages/react/src/r5/inputs/input-types/fhir-input-resource.tsx
+++ b/packages/react/src/r5/inputs/input-types/fhir-input-resource.tsx
@@ -2,11 +2,13 @@ import {
   AnyResourceType,
   ExtractResource,
   FhirClientSearchParameters,
+  FhirSearchBuilder,
   Reference,
   Resource,
   ResourceTypeOf,
   cloneResource,
   id,
+  normalizeSearchParameters,
   reference,
 } from "@bonfhir/core/r5";
 import { useFhirRead, useFhirSearch } from "@bonfhir/query/r5";
@@ -71,9 +73,15 @@ export function FhirInputResource<
     value: valueQuery.data || undefined,
     onSearch: (query: string) => {
       if (props.search) {
-        setSearchParams(props.search(query));
+        const normalizedSearch = normalizeSearchParameters(
+          props.resourceType,
+          props.search(query),
+        );
+        setSearchParams(normalizedSearch ?? "");
       } else {
-        setSearchParams("");
+        setSearchParams(
+          new FhirSearchBuilder().stringParam("_text", query).href,
+        );
       }
     },
     onChange: (value: Resource | undefined) => {
@@ -95,6 +103,7 @@ export function FhirInputResource<
       ((resource: Resource) =>
         reference(resource as any)?.display ??
         `${resource.resourceType}/${resource.id}`),
+    error: valueQuery.error ?? searchQuery.error,
   });
 }
 
@@ -105,6 +114,7 @@ export type FhirInputResourceRendererProps<TRendererProps = any> =
     onSearch: (query: string) => void;
     data: Resource[];
     display: (resource: Resource) => string;
+    error: unknown | undefined;
   };
 
 export type FhirInputResourceRenderer = (


### PR DESCRIPTION
Add managingOrganization field to EditPatient component and update FhirInputResource component.

- search can now be a function
- search defaults to `_text=`
- display query errors
- support form reset

Fix #113.