### PR TITLE
`extendResource` enhancements

### DIFF
--- a/.changeset/bright-goats-teach.md
+++ b/.changeset/bright-goats-teach.md
@@ -1,0 +1,5 @@
+---
+"@bonfhir/core": minor
+---
+
+Fix #133 - add `toFhirResource` to extended resources

--- a/.changeset/red-cobras-tickle.md
+++ b/.changeset/red-cobras-tickle.md
@@ -1,0 +1,5 @@
+---
+"@bonfhir/core": minor
+---
+
+Fix #136 - add profile to `extendResource`

--- a/.changeset/silent-mangos-repeat.md
+++ b/.changeset/silent-mangos-repeat.md
@@ -1,0 +1,5 @@
+---
+"@bonfhir/core": minor
+---
+
+Fix #137 - add `onFhirResource` callback to `extendResource`

--- a/packages/core/jest.config.mjs
+++ b/packages/core/jest.config.mjs
@@ -1,6 +1,7 @@
 /** @type {import('jest').Config} */
 export default {
   globalSetup: "<rootDir>/jest.setup.mjs",
+  prettierPath: undefined, // https://jestjs.io/docs/configuration/#prettierpath-string
   transform: {
     "^.+\\.(t|j)sx?$": ["esbuild-jest", { sourcemap: true }],
   },

--- a/packages/core/src/r4b/extensions.test.ts
+++ b/packages/core/src/r4b/extensions.test.ts
@@ -36,6 +36,13 @@ describe("extensions", () => {
     },
     {
       profile: "http://custom/diagnostic-report",
+      onFhirResource: (resource) => {
+        if (resource.code?.text) {
+          resource.code.text = resource.code.text.toUpperCase();
+        }
+
+        return resource;
+      },
     },
   );
 
@@ -114,7 +121,7 @@ describe("extensions", () => {
           "resourceType": "DiagnosticReport",
           "status": "preliminary",
           "code": {
-            "text": "Diag"
+            "text": "DIAG"
           },
           "extension": [
             {
@@ -141,7 +148,7 @@ describe("extensions", () => {
           "resourceType": "DiagnosticReport",
           "status": "preliminary",
           "code": {
-            "text": "Diag"
+            "text": "DIAG"
           },
           "extension": [
             {
@@ -155,7 +162,7 @@ describe("extensions", () => {
           ],
           "text": {
             "status": "generated",
-            "div": "<div xmlns=\\"http://www.w3.org/1999/xhtml\\"><ul><li><span>Code: </span>Diag</li><li><span>Status: </span>preliminary</li></ul></div>"
+            "div": "<div xmlns=\\"http://www.w3.org/1999/xhtml\\"><ul><li><span>Code: </span>DIAG</li><li><span>Status: </span>preliminary</li></ul></div>"
           },
           "meta": {
             "profile": [
@@ -173,11 +180,11 @@ describe("extensions", () => {
           "resourceType": "DiagnosticReport",
           "status": "preliminary",
           "code": {
-            "text": "Diag"
+            "text": "DIAG"
           },
           "text": {
             "status": "generated",
-            "div": "<div xmlns=\\"http://www.w3.org/1999/xhtml\\"><ul><li><span>Code: </span>Diag</li><li><span>Status: </span>preliminary</li></ul></div>"
+            "div": "<div xmlns=\\"http://www.w3.org/1999/xhtml\\"><ul><li><span>Code: </span>DIAG</li><li><span>Status: </span>preliminary</li></ul></div>"
           },
           "meta": {
             "profile": [
@@ -203,7 +210,7 @@ describe("extensions", () => {
           "resourceType": "DiagnosticReport",
           "status": "preliminary",
           "code": {
-            "text": "Diag"
+            "text": "DIAG"
           },
           "meta": {
             "tag": [
@@ -231,7 +238,7 @@ describe("extensions", () => {
           "resourceType": "DiagnosticReport",
           "status": "preliminary",
           "code": {
-            "text": "Diag"
+            "text": "DIAG"
           },
           "meta": {
             "tag": [
@@ -246,7 +253,7 @@ describe("extensions", () => {
           },
           "text": {
             "status": "generated",
-            "div": "<div xmlns=\\"http://www.w3.org/1999/xhtml\\"><ul><li><span>Code: </span>Diag</li><li><span>Status: </span>preliminary</li></ul></div>"
+            "div": "<div xmlns=\\"http://www.w3.org/1999/xhtml\\"><ul><li><span>Code: </span>DIAG</li><li><span>Status: </span>preliminary</li></ul></div>"
           }
         }"
       `);
@@ -258,7 +265,7 @@ describe("extensions", () => {
           "resourceType": "DiagnosticReport",
           "status": "preliminary",
           "code": {
-            "text": "Diag"
+            "text": "DIAG"
           },
           "meta": {
             "profile": [
@@ -267,7 +274,7 @@ describe("extensions", () => {
           },
           "text": {
             "status": "generated",
-            "div": "<div xmlns=\\"http://www.w3.org/1999/xhtml\\"><ul><li><span>Code: </span>Diag</li><li><span>Status: </span>preliminary</li></ul></div>"
+            "div": "<div xmlns=\\"http://www.w3.org/1999/xhtml\\"><ul><li><span>Code: </span>DIAG</li><li><span>Status: </span>preliminary</li></ul></div>"
           }
         }"
       `);
@@ -334,7 +341,7 @@ describe("extensions", () => {
           "resourceType": "DiagnosticReport",
           "status": "preliminary",
           "code": {
-            "text": "Diag"
+            "text": "DIAG"
           },
           "meta": {
             "source": "http://example.com",

--- a/packages/core/src/r4b/extensions.test.ts
+++ b/packages/core/src/r4b/extensions.test.ts
@@ -356,4 +356,23 @@ describe("extensions", () => {
         }"
       `);
   });
+
+  it("return the FHIR resource representation", () => {
+    const patient = new CustomPatient();
+    patient.birthSex = "OTH";
+
+    expect(patient.toFhirResource()).toMatchObject({
+      resourceType: "Patient",
+      extension: [
+        {
+          url: "http://hl7.org/fhir/us/core/StructureDefinition/us-core-birthsex",
+          valueCode: "OTH",
+        },
+      ],
+      text: {
+        status: "generated",
+        div: '<div xmlns="http://www.w3.org/1999/xhtml"><ul></ul></div>',
+      },
+    });
+  });
 });

--- a/packages/core/src/r4b/extensions.test.ts
+++ b/packages/core/src/r4b/extensions.test.ts
@@ -19,19 +19,25 @@ describe("extensions", () => {
     }),
   });
 
-  const CustomDiagnosticReport = extendResource("DiagnosticReport", {
-    cptCodes: extension({
-      url: "http://custom/cpt-codes",
-      kind: "valueCode",
-      allowMultiple: true,
-    }),
+  const CustomDiagnosticReport = extendResource(
+    "DiagnosticReport",
+    {
+      cptCodes: extension({
+        url: "http://custom/cpt-codes",
+        kind: "valueCode",
+        allowMultiple: true,
+      }),
 
-    visibility: tag({ system: "http://custom/visibility" }),
+      visibility: tag({ system: "http://custom/visibility" }),
 
-    isPubliclyVisible(): boolean {
-      return this.visibility?.code === "public";
+      isPubliclyVisible(): boolean {
+        return this.visibility?.code === "public";
+      },
     },
-  });
+    {
+      profile: "http://custom/diagnostic-report",
+    },
+  );
 
   it("manage computed properties", () => {
     const patient = new CustomPatient({
@@ -119,6 +125,11 @@ describe("extensions", () => {
           "text": {
             "status": "generated",
             "div": "<div xmlns=\\"http://www.w3.org/1999/xhtml\\"><ul><li><span>Code: </span>Diag</li><li><span>Status: </span>preliminary</li></ul></div>"
+          },
+          "meta": {
+            "profile": [
+              "http://custom/diagnostic-report"
+            ]
           }
         }"
       `);
@@ -145,6 +156,11 @@ describe("extensions", () => {
           "text": {
             "status": "generated",
             "div": "<div xmlns=\\"http://www.w3.org/1999/xhtml\\"><ul><li><span>Code: </span>Diag</li><li><span>Status: </span>preliminary</li></ul></div>"
+          },
+          "meta": {
+            "profile": [
+              "http://custom/diagnostic-report"
+            ]
           }
         }"
       `);
@@ -162,6 +178,11 @@ describe("extensions", () => {
           "text": {
             "status": "generated",
             "div": "<div xmlns=\\"http://www.w3.org/1999/xhtml\\"><ul><li><span>Code: </span>Diag</li><li><span>Status: </span>preliminary</li></ul></div>"
+          },
+          "meta": {
+            "profile": [
+              "http://custom/diagnostic-report"
+            ]
           }
         }"
       `);
@@ -190,6 +211,9 @@ describe("extensions", () => {
                 "code": "public",
                 "system": "http://custom/visibility"
               }
+            ],
+            "profile": [
+              "http://custom/diagnostic-report"
             ]
           },
           "text": {
@@ -215,6 +239,9 @@ describe("extensions", () => {
                 "code": "internal",
                 "system": "http://custom/visibility"
               }
+            ],
+            "profile": [
+              "http://custom/diagnostic-report"
             ]
           },
           "text": {
@@ -232,6 +259,11 @@ describe("extensions", () => {
           "status": "preliminary",
           "code": {
             "text": "Diag"
+          },
+          "meta": {
+            "profile": [
+              "http://custom/diagnostic-report"
+            ]
           },
           "text": {
             "status": "generated",
@@ -286,5 +318,35 @@ describe("extensions", () => {
         "birthSex",
       ]
     `);
+  });
+
+  it("merge meta", () => {
+    const diagnosticReport = new CustomDiagnosticReport({
+      status: "preliminary",
+      code: { text: "Diag" },
+      meta: {
+        source: "http://example.com",
+      },
+    });
+    expect(JSON.stringify(diagnosticReport, undefined, 2))
+      .toMatchInlineSnapshot(`
+        "{
+          "resourceType": "DiagnosticReport",
+          "status": "preliminary",
+          "code": {
+            "text": "Diag"
+          },
+          "meta": {
+            "source": "http://example.com",
+            "profile": [
+              "http://custom/diagnostic-report"
+            ]
+          },
+          "text": {
+            "status": "generated",
+            "div": "<div xmlns=\\"http://www.w3.org/1999/xhtml\\"><ul><li><span>Code: </span>Diag</li><li><span>Status: </span>preliminary</li></ul></div>"
+          }
+        }"
+      `);
   });
 });

--- a/packages/core/src/r5/extensions.test.ts
+++ b/packages/core/src/r5/extensions.test.ts
@@ -36,6 +36,13 @@ describe("extensions", () => {
     },
     {
       profile: "http://custom/diagnostic-report",
+      onFhirResource: (resource) => {
+        if (resource.code?.text) {
+          resource.code.text = resource.code.text.toUpperCase();
+        }
+
+        return resource;
+      },
     },
   );
 
@@ -114,7 +121,7 @@ describe("extensions", () => {
           "resourceType": "DiagnosticReport",
           "status": "preliminary",
           "code": {
-            "text": "Diag"
+            "text": "DIAG"
           },
           "extension": [
             {
@@ -141,7 +148,7 @@ describe("extensions", () => {
           "resourceType": "DiagnosticReport",
           "status": "preliminary",
           "code": {
-            "text": "Diag"
+            "text": "DIAG"
           },
           "extension": [
             {
@@ -155,7 +162,7 @@ describe("extensions", () => {
           ],
           "text": {
             "status": "generated",
-            "div": "<div xmlns=\\"http://www.w3.org/1999/xhtml\\"><ul><li><span>Code: </span>Diag</li><li><span>Status: </span>preliminary</li></ul></div>"
+            "div": "<div xmlns=\\"http://www.w3.org/1999/xhtml\\"><ul><li><span>Code: </span>DIAG</li><li><span>Status: </span>preliminary</li></ul></div>"
           },
           "meta": {
             "profile": [
@@ -173,11 +180,11 @@ describe("extensions", () => {
           "resourceType": "DiagnosticReport",
           "status": "preliminary",
           "code": {
-            "text": "Diag"
+            "text": "DIAG"
           },
           "text": {
             "status": "generated",
-            "div": "<div xmlns=\\"http://www.w3.org/1999/xhtml\\"><ul><li><span>Code: </span>Diag</li><li><span>Status: </span>preliminary</li></ul></div>"
+            "div": "<div xmlns=\\"http://www.w3.org/1999/xhtml\\"><ul><li><span>Code: </span>DIAG</li><li><span>Status: </span>preliminary</li></ul></div>"
           },
           "meta": {
             "profile": [
@@ -203,7 +210,7 @@ describe("extensions", () => {
           "resourceType": "DiagnosticReport",
           "status": "preliminary",
           "code": {
-            "text": "Diag"
+            "text": "DIAG"
           },
           "meta": {
             "tag": [
@@ -231,7 +238,7 @@ describe("extensions", () => {
           "resourceType": "DiagnosticReport",
           "status": "preliminary",
           "code": {
-            "text": "Diag"
+            "text": "DIAG"
           },
           "meta": {
             "tag": [
@@ -246,7 +253,7 @@ describe("extensions", () => {
           },
           "text": {
             "status": "generated",
-            "div": "<div xmlns=\\"http://www.w3.org/1999/xhtml\\"><ul><li><span>Code: </span>Diag</li><li><span>Status: </span>preliminary</li></ul></div>"
+            "div": "<div xmlns=\\"http://www.w3.org/1999/xhtml\\"><ul><li><span>Code: </span>DIAG</li><li><span>Status: </span>preliminary</li></ul></div>"
           }
         }"
       `);
@@ -258,7 +265,7 @@ describe("extensions", () => {
           "resourceType": "DiagnosticReport",
           "status": "preliminary",
           "code": {
-            "text": "Diag"
+            "text": "DIAG"
           },
           "meta": {
             "profile": [
@@ -267,7 +274,7 @@ describe("extensions", () => {
           },
           "text": {
             "status": "generated",
-            "div": "<div xmlns=\\"http://www.w3.org/1999/xhtml\\"><ul><li><span>Code: </span>Diag</li><li><span>Status: </span>preliminary</li></ul></div>"
+            "div": "<div xmlns=\\"http://www.w3.org/1999/xhtml\\"><ul><li><span>Code: </span>DIAG</li><li><span>Status: </span>preliminary</li></ul></div>"
           }
         }"
       `);
@@ -334,7 +341,7 @@ describe("extensions", () => {
           "resourceType": "DiagnosticReport",
           "status": "preliminary",
           "code": {
-            "text": "Diag"
+            "text": "DIAG"
           },
           "meta": {
             "source": "http://example.com",

--- a/packages/core/src/r5/extensions.test.ts
+++ b/packages/core/src/r5/extensions.test.ts
@@ -356,4 +356,23 @@ describe("extensions", () => {
         }"
       `);
   });
+
+  it("return the FHIR resource representation", () => {
+    const patient = new CustomPatient();
+    patient.birthSex = "OTH";
+
+    expect(patient.toFhirResource()).toMatchObject({
+      resourceType: "Patient",
+      extension: [
+        {
+          url: "http://hl7.org/fhir/us/core/StructureDefinition/us-core-birthsex",
+          valueCode: "OTH",
+        },
+      ],
+      text: {
+        status: "generated",
+        div: '<div xmlns="http://www.w3.org/1999/xhtml"><ul></ul></div>',
+      },
+    });
+  });
 });

--- a/packages/core/src/r5/extensions.test.ts
+++ b/packages/core/src/r5/extensions.test.ts
@@ -19,19 +19,25 @@ describe("extensions", () => {
     }),
   });
 
-  const CustomDiagnosticReport = extendResource("DiagnosticReport", {
-    cptCodes: extension({
-      url: "http://custom/cpt-codes",
-      kind: "valueCode",
-      allowMultiple: true,
-    }),
+  const CustomDiagnosticReport = extendResource(
+    "DiagnosticReport",
+    {
+      cptCodes: extension({
+        url: "http://custom/cpt-codes",
+        kind: "valueCode",
+        allowMultiple: true,
+      }),
 
-    visibility: tag({ system: "http://custom/visibility" }),
+      visibility: tag({ system: "http://custom/visibility" }),
 
-    isPubliclyVisible(): boolean {
-      return this.visibility?.code === "public";
+      isPubliclyVisible(): boolean {
+        return this.visibility?.code === "public";
+      },
     },
-  });
+    {
+      profile: "http://custom/diagnostic-report",
+    },
+  );
 
   it("manage computed properties", () => {
     const patient = new CustomPatient({
@@ -119,6 +125,11 @@ describe("extensions", () => {
           "text": {
             "status": "generated",
             "div": "<div xmlns=\\"http://www.w3.org/1999/xhtml\\"><ul><li><span>Code: </span>Diag</li><li><span>Status: </span>preliminary</li></ul></div>"
+          },
+          "meta": {
+            "profile": [
+              "http://custom/diagnostic-report"
+            ]
           }
         }"
       `);
@@ -145,6 +156,11 @@ describe("extensions", () => {
           "text": {
             "status": "generated",
             "div": "<div xmlns=\\"http://www.w3.org/1999/xhtml\\"><ul><li><span>Code: </span>Diag</li><li><span>Status: </span>preliminary</li></ul></div>"
+          },
+          "meta": {
+            "profile": [
+              "http://custom/diagnostic-report"
+            ]
           }
         }"
       `);
@@ -162,6 +178,11 @@ describe("extensions", () => {
           "text": {
             "status": "generated",
             "div": "<div xmlns=\\"http://www.w3.org/1999/xhtml\\"><ul><li><span>Code: </span>Diag</li><li><span>Status: </span>preliminary</li></ul></div>"
+          },
+          "meta": {
+            "profile": [
+              "http://custom/diagnostic-report"
+            ]
           }
         }"
       `);
@@ -190,6 +211,9 @@ describe("extensions", () => {
                 "code": "public",
                 "system": "http://custom/visibility"
               }
+            ],
+            "profile": [
+              "http://custom/diagnostic-report"
             ]
           },
           "text": {
@@ -215,6 +239,9 @@ describe("extensions", () => {
                 "code": "internal",
                 "system": "http://custom/visibility"
               }
+            ],
+            "profile": [
+              "http://custom/diagnostic-report"
             ]
           },
           "text": {
@@ -232,6 +259,11 @@ describe("extensions", () => {
           "status": "preliminary",
           "code": {
             "text": "Diag"
+          },
+          "meta": {
+            "profile": [
+              "http://custom/diagnostic-report"
+            ]
           },
           "text": {
             "status": "generated",
@@ -286,5 +318,35 @@ describe("extensions", () => {
         "birthSex",
       ]
     `);
+  });
+
+  it("merge meta", () => {
+    const diagnosticReport = new CustomDiagnosticReport({
+      status: "preliminary",
+      code: { text: "Diag" },
+      meta: {
+        source: "http://example.com",
+      },
+    });
+    expect(JSON.stringify(diagnosticReport, undefined, 2))
+      .toMatchInlineSnapshot(`
+        "{
+          "resourceType": "DiagnosticReport",
+          "status": "preliminary",
+          "code": {
+            "text": "Diag"
+          },
+          "meta": {
+            "source": "http://example.com",
+            "profile": [
+              "http://custom/diagnostic-report"
+            ]
+          },
+          "text": {
+            "status": "generated",
+            "div": "<div xmlns=\\"http://www.w3.org/1999/xhtml\\"><ul><li><span>Code: </span>Diag</li><li><span>Status: </span>preliminary</li></ul></div>"
+          }
+        }"
+      `);
   });
 });


### PR DESCRIPTION
This pull request adds the following changes:

- Fix #136: Adds a profile option to the extendResource function to support setting the Meta.profile value during serialization.

- Fix #137: Refactors the extendResource function to support a custom onFhirResource callback that allows interception and modification prior to serialization.

- Fix #133: Adds a toFhirResource method to extended resources, which returns the original FHIR resource without the custom properties.

Code exemple:

```typescript
const CustomDiagnosticReport = extendResource(
  "DiagnosticReport",
  {
    cptCodes: extension({
      url: "http://custom/cpt-codes",
      kind: "valueCode",
      allowMultiple: true,
    }),

    visibility: tag({ system: "http://custom/visibility" }),

    isPubliclyVisible(): boolean {
      return this.visibility?.code === "public";
    },
  },
  {
    profile: "http://custom/diagnostic-report",
    onFhirResource: (resource) => {
      if (resource.code?.text) {
        resource.code.text = resource.code.text.toUpperCase();
      }

      return resource;
    },
  },
);

const diagnosticReport = new CustomDiagnosticReport({
  status: "preliminary",
  code: { text: "Diag" },
});

diagnosticReport.toFhirResource();
```