### PR TITLE
Fix `decorator` in `formatter` seems to duplicate the content sometime #143

### DIFF
--- a/.changeset/olive-apes-kneel.md
+++ b/.changeset/olive-apes-kneel.md
@@ -1,0 +1,5 @@
+---
+"@bonfhir/core": patch
+---
+
+Fix #143 - duplicated decorator

--- a/packages/core/src/r4b/formatters.test.ts
+++ b/packages/core/src/r4b/formatters.test.ts
@@ -41,6 +41,25 @@ describe("formatters", () => {
         }),
         "Age: 3 years old",
       ],
+      [
+        Formatter.default.format(
+          "CodeableConcept",
+          {
+            coding: [
+              {
+                system:
+                  "http://terminology.hl7.org/CodeSystem/condition-clinical",
+                code: "active",
+                display: "Active",
+              },
+            ],
+          },
+          {
+            decorator: "Status: {}",
+          },
+        ),
+        "Status: Active",
+      ],
     ])("%p => %p", (expression, expected) => {
       expect(expression).toEqual(expected);
     });

--- a/packages/core/src/r4b/formatters.ts
+++ b/packages/core/src/r4b/formatters.ts
@@ -75,6 +75,25 @@ export interface CommonFormatterOptions {
 }
 
 /**
+ * Remove the common options from a formatter options object so that they are not applied multiple times.
+ * Has to be used when passing whole upstream options to downstream formatters.
+ */
+export function cleanUpCommonOptions<T>(
+  options: T | null | undefined,
+): Omit<T, "default" | "decorator"> | undefined {
+  if (!options || typeof options !== "object") {
+    return undefined;
+  }
+
+  const {
+    default: defaultOmitted,
+    decorator: decoratorOmitted,
+    ...otherOptions
+  } = options as T & CommonFormatterOptions;
+  return otherOptions;
+}
+
+/**
  * Extends the base Formatter type with an overload of the format function that fits the ValueFormatter.
  */
 export type WithTypedFormatFunction<

--- a/packages/core/src/r4b/value-formatters/address.ts
+++ b/packages/core/src/r4b/value-formatters/address.ts
@@ -1,6 +1,10 @@
 import { formatAddress } from "localized-address-format";
 import { Address } from "../fhir-types.codegen";
-import { ValueFormatter, withValueFormatter } from "../formatters";
+import {
+  ValueFormatter,
+  cleanUpCommonOptions,
+  withValueFormatter,
+} from "../formatters";
 import { comparePeriods } from "../lang-utils";
 import { CodeFormatterOptions, codeFormatter } from "./code";
 import { periodFormatter } from "./period";
@@ -78,7 +82,7 @@ export const addressFormatter: ValueFormatter<
         .map((address) =>
           withValueFormatter<typeof addressFormatter>(
             formatterOptions.formatter,
-          ).format("Address", address, options),
+          ).format("Address", address, cleanUpCommonOptions(options)),
         )
         .filter(Boolean);
 

--- a/packages/core/src/r4b/value-formatters/codeable-concept.ts
+++ b/packages/core/src/r4b/value-formatters/codeable-concept.ts
@@ -1,5 +1,9 @@
 import { CodeableConcept } from "../fhir-types.codegen";
-import { ValueFormatter, withValueFormatter } from "../formatters";
+import {
+  ValueFormatter,
+  cleanUpCommonOptions,
+  withValueFormatter,
+} from "../formatters";
 import { CodingFormatterOptions, codingFormatter } from "./coding";
 
 /**
@@ -44,7 +48,7 @@ export const codeableConceptFormatter: ValueFormatter<
     } else if (codings.length === 1) {
       return withValueFormatter<typeof codingFormatter>(
         formatterOptions.formatter,
-      ).format("Coding", codings[0], options);
+      ).format("Coding", codings[0], cleanUpCommonOptions(options));
     }
 
     return new Intl.ListFormat(
@@ -54,7 +58,7 @@ export const codeableConceptFormatter: ValueFormatter<
       codings.map((coding) =>
         withValueFormatter<typeof codingFormatter>(
           formatterOptions.formatter,
-        ).format("Coding", coding, options),
+        ).format("Coding", coding, cleanUpCommonOptions(options)),
       ),
     );
   },

--- a/packages/core/src/r4b/value-formatters/contact-point.ts
+++ b/packages/core/src/r4b/value-formatters/contact-point.ts
@@ -1,5 +1,9 @@
 import { ContactPoint } from "../fhir-types.codegen";
-import { ValueFormatter, withValueFormatter } from "../formatters";
+import {
+  ValueFormatter,
+  cleanUpCommonOptions,
+  withValueFormatter,
+} from "../formatters";
 import { CodeFormatterOptions, codeFormatter } from "./code";
 import { periodFormatter } from "./period";
 
@@ -62,7 +66,7 @@ export const contactPointFormatter: ValueFormatter<
         .map((contactPoint) =>
           withValueFormatter<typeof contactPointFormatter>(
             formatterOptions.formatter,
-          ).format("ContactPoint", contactPoint, options),
+          ).format("ContactPoint", contactPoint, cleanUpCommonOptions(options)),
         )
         .filter(Boolean);
 

--- a/packages/core/src/r4b/value-formatters/human-name.ts
+++ b/packages/core/src/r4b/value-formatters/human-name.ts
@@ -1,7 +1,11 @@
 import { periodFormatter } from ".";
 import { formatWithTokens } from "..";
 import { HumanName, NameUse } from "../fhir-types.codegen";
-import { ValueFormatter, withValueFormatter } from "../formatters";
+import {
+  ValueFormatter,
+  cleanUpCommonOptions,
+  withValueFormatter,
+} from "../formatters";
 import { CodeFormatterOptions, codeFormatter } from "./code";
 
 /**
@@ -92,7 +96,7 @@ export const humanNameFormatter: ValueFormatter<
         .map((humanName) =>
           withValueFormatter<typeof humanNameFormatter>(
             formatterOptions.formatter,
-          ).format("HumanName", humanName, options),
+          ).format("HumanName", humanName, cleanUpCommonOptions(options)),
         )
         .filter(Boolean);
 

--- a/packages/core/src/r4b/value-formatters/identifier.ts
+++ b/packages/core/src/r4b/value-formatters/identifier.ts
@@ -1,5 +1,9 @@
 import { Identifier } from "../fhir-types.codegen";
-import { ValueFormatter, withValueFormatter } from "../formatters";
+import {
+  ValueFormatter,
+  cleanUpCommonOptions,
+  withValueFormatter,
+} from "../formatters";
 import { comparePeriods, formatValueWithPattern } from "../lang-utils";
 import { CodeFormatterOptions, codeFormatter } from "./code";
 import { codeableConceptFormatter } from "./codeable-concept";
@@ -87,7 +91,7 @@ export const identifierFormatter: ValueFormatter<
         .map((identifier) =>
           withValueFormatter<typeof identifierFormatter>(
             formatterOptions.formatter,
-          ).format("Identifier", identifier, options),
+          ).format("Identifier", identifier, cleanUpCommonOptions(options)),
         )
         .filter(Boolean);
 

--- a/packages/core/src/r4b/value-formatters/period.ts
+++ b/packages/core/src/r4b/value-formatters/period.ts
@@ -1,5 +1,9 @@
 import { Period } from "../fhir-types.codegen";
-import { ValueFormatter, withValueFormatter } from "../formatters";
+import {
+  ValueFormatter,
+  cleanUpCommonOptions,
+  withValueFormatter,
+} from "../formatters";
 import { DatetimeFormatterOptions, dateTimeFormatter } from "./date-time";
 
 export type PeriodFormatterOptions = DatetimeFormatterOptions;
@@ -15,11 +19,11 @@ export const periodFormatter: ValueFormatter<
 
     const formattedStartDateTime = withValueFormatter<typeof dateTimeFormatter>(
       formatterOptions.formatter,
-    ).format("dateTime", value.start, options);
+    ).format("dateTime", value.start, cleanUpCommonOptions(options));
     const formattedEndDateTime = value.end
       ? withValueFormatter<typeof dateTimeFormatter>(
           formatterOptions.formatter,
-        ).format("dateTime", value.end, options)
+        ).format("dateTime", value.end, cleanUpCommonOptions(options))
       : "ongoing";
 
     return [formattedStartDateTime, "-", formattedEndDateTime]

--- a/packages/core/src/r5/formatters.test.ts
+++ b/packages/core/src/r5/formatters.test.ts
@@ -41,6 +41,25 @@ describe("formatters", () => {
         }),
         "Age: 3 years old",
       ],
+      [
+        Formatter.default.format(
+          "CodeableConcept",
+          {
+            coding: [
+              {
+                system:
+                  "http://terminology.hl7.org/CodeSystem/condition-clinical",
+                code: "active",
+                display: "Active",
+              },
+            ],
+          },
+          {
+            decorator: "Status: {}",
+          },
+        ),
+        "Status: Active",
+      ],
     ])("%p => %p", (expression, expected) => {
       expect(expression).toEqual(expected);
     });

--- a/packages/core/src/r5/formatters.ts
+++ b/packages/core/src/r5/formatters.ts
@@ -76,6 +76,25 @@ export interface CommonFormatterOptions {
 }
 
 /**
+ * Remove the common options from a formatter options object so that they are not applied multiple times.
+ * Has to be used when passing whole upstream options to downstream formatters.
+ */
+export function cleanUpCommonOptions<T>(
+  options: T | null | undefined,
+): Omit<T, "default" | "decorator"> | undefined {
+  if (!options || typeof options !== "object") {
+    return undefined;
+  }
+
+  const {
+    default: defaultOmitted,
+    decorator: decoratorOmitted,
+    ...otherOptions
+  } = options as T & CommonFormatterOptions;
+  return otherOptions;
+}
+
+/**
  * Extends the base Formatter type with an overload of the format function that fits the ValueFormatter.
  */
 export type WithTypedFormatFunction<

--- a/packages/core/src/r5/value-formatters/address.ts
+++ b/packages/core/src/r5/value-formatters/address.ts
@@ -1,6 +1,10 @@
 import { formatAddress } from "localized-address-format";
 import { Address } from "../fhir-types.codegen";
-import { ValueFormatter, withValueFormatter } from "../formatters";
+import {
+  ValueFormatter,
+  cleanUpCommonOptions,
+  withValueFormatter,
+} from "../formatters";
 import { comparePeriods } from "../lang-utils";
 import { CodeFormatterOptions, codeFormatter } from "./code";
 import { periodFormatter } from "./period";
@@ -78,7 +82,7 @@ export const addressFormatter: ValueFormatter<
         .map((address) =>
           withValueFormatter<typeof addressFormatter>(
             formatterOptions.formatter,
-          ).format("Address", address, options),
+          ).format("Address", address, cleanUpCommonOptions(options)),
         )
         .filter(Boolean);
 

--- a/packages/core/src/r5/value-formatters/codeable-concept.ts
+++ b/packages/core/src/r5/value-formatters/codeable-concept.ts
@@ -1,5 +1,9 @@
 import { CodeableConcept } from "../fhir-types.codegen";
-import { ValueFormatter, withValueFormatter } from "../formatters";
+import {
+  ValueFormatter,
+  cleanUpCommonOptions,
+  withValueFormatter,
+} from "../formatters";
 import { CodingFormatterOptions, codingFormatter } from "./coding";
 
 /**
@@ -44,7 +48,7 @@ export const codeableConceptFormatter: ValueFormatter<
     } else if (codings.length === 1) {
       return withValueFormatter<typeof codingFormatter>(
         formatterOptions.formatter,
-      ).format("Coding", codings[0], options);
+      ).format("Coding", codings[0], cleanUpCommonOptions(options));
     }
 
     return new Intl.ListFormat(
@@ -54,7 +58,7 @@ export const codeableConceptFormatter: ValueFormatter<
       codings.map((coding) =>
         withValueFormatter<typeof codingFormatter>(
           formatterOptions.formatter,
-        ).format("Coding", coding, options),
+        ).format("Coding", coding, cleanUpCommonOptions(options)),
       ),
     );
   },

--- a/packages/core/src/r5/value-formatters/contact-point.ts
+++ b/packages/core/src/r5/value-formatters/contact-point.ts
@@ -1,5 +1,9 @@
 import { ContactPoint } from "../fhir-types.codegen";
-import { ValueFormatter, withValueFormatter } from "../formatters";
+import {
+  ValueFormatter,
+  cleanUpCommonOptions,
+  withValueFormatter,
+} from "../formatters";
 import { CodeFormatterOptions, codeFormatter } from "./code";
 import { periodFormatter } from "./period";
 
@@ -62,7 +66,7 @@ export const contactPointFormatter: ValueFormatter<
         .map((contactPoint) =>
           withValueFormatter<typeof contactPointFormatter>(
             formatterOptions.formatter,
-          ).format("ContactPoint", contactPoint, options),
+          ).format("ContactPoint", contactPoint, cleanUpCommonOptions(options)),
         )
         .filter(Boolean);
 

--- a/packages/core/src/r5/value-formatters/human-name.ts
+++ b/packages/core/src/r5/value-formatters/human-name.ts
@@ -1,7 +1,11 @@
 import { periodFormatter } from ".";
 import { formatWithTokens } from "..";
 import { HumanName, NameUse } from "../fhir-types.codegen";
-import { ValueFormatter, withValueFormatter } from "../formatters";
+import {
+  ValueFormatter,
+  cleanUpCommonOptions,
+  withValueFormatter,
+} from "../formatters";
 import { CodeFormatterOptions, codeFormatter } from "./code";
 
 /**
@@ -92,7 +96,7 @@ export const humanNameFormatter: ValueFormatter<
         .map((humanName) =>
           withValueFormatter<typeof humanNameFormatter>(
             formatterOptions.formatter,
-          ).format("HumanName", humanName, options),
+          ).format("HumanName", humanName, cleanUpCommonOptions(options)),
         )
         .filter(Boolean);
 

--- a/packages/core/src/r5/value-formatters/identifier.ts
+++ b/packages/core/src/r5/value-formatters/identifier.ts
@@ -1,5 +1,9 @@
 import { Identifier } from "../fhir-types.codegen";
-import { ValueFormatter, withValueFormatter } from "../formatters";
+import {
+  ValueFormatter,
+  cleanUpCommonOptions,
+  withValueFormatter,
+} from "../formatters";
 import { comparePeriods, formatValueWithPattern } from "../lang-utils";
 import { CodeFormatterOptions, codeFormatter } from "./code";
 import { codeableConceptFormatter } from "./codeable-concept";
@@ -87,7 +91,7 @@ export const identifierFormatter: ValueFormatter<
         .map((identifier) =>
           withValueFormatter<typeof identifierFormatter>(
             formatterOptions.formatter,
-          ).format("Identifier", identifier, options),
+          ).format("Identifier", identifier, cleanUpCommonOptions(options)),
         )
         .filter(Boolean);
 

--- a/packages/core/src/r5/value-formatters/period.ts
+++ b/packages/core/src/r5/value-formatters/period.ts
@@ -1,5 +1,9 @@
 import { Period } from "../fhir-types.codegen";
-import { ValueFormatter, withValueFormatter } from "../formatters";
+import {
+  ValueFormatter,
+  cleanUpCommonOptions,
+  withValueFormatter,
+} from "../formatters";
 import { DatetimeFormatterOptions, dateTimeFormatter } from "./date-time";
 
 export type PeriodFormatterOptions = DatetimeFormatterOptions;
@@ -15,11 +19,11 @@ export const periodFormatter: ValueFormatter<
 
     const formattedStartDateTime = withValueFormatter<typeof dateTimeFormatter>(
       formatterOptions.formatter,
-    ).format("dateTime", value.start, options);
+    ).format("dateTime", value.start, cleanUpCommonOptions(options));
     const formattedEndDateTime = value.end
       ? withValueFormatter<typeof dateTimeFormatter>(
           formatterOptions.formatter,
-        ).format("dateTime", value.end, options)
+        ).format("dateTime", value.end, cleanUpCommonOptions(options))
       : "ongoing";
 
     return [formattedStartDateTime, "-", formattedEndDateTime]


### PR DESCRIPTION
The decorator was applied recursively in a number of formatters.
 I added a function to clean-up common options to avoid multiple applications when we chose to pass the whole options object.

Fix #143