### PR TITLE
`useFhirRead` and `useFhirVRead` now accepts undefined/null/empty and disable the query

### DIFF
--- a/.changeset/smart-deers-tease.md
+++ b/.changeset/smart-deers-tease.md
@@ -1,0 +1,7 @@
+---
+"@bonfhir/query": patch
+---
+
+Fix #140 - `useFhirRead` and `useFhirVRead` now accepts undefined/null/empty and disable the query
+
+This makes working with async router a lot easier

--- a/apps/sample-ehr/src/app/patients/[patientId]/layout.tsx
+++ b/apps/sample-ehr/src/app/patients/[patientId]/layout.tsx
@@ -56,9 +56,8 @@ export default function PatientLayout({ children }: PropsWithChildren) {
   const patientId = pathname?.split("/")?.[2];
   const activeTab = pathname.split("/")?.[3] || tabs[0].value;
 
-  const patientQuery = useFhirRead("Patient", patientId!, {
+  const patientQuery = useFhirRead("Patient", patientId, {
     query: {
-      enabled: Boolean(patientId),
       onSuccess(patient) {
         if (patient) {
           document.title = formatter.format("HumanName", patient.name, {

--- a/packages/query/src/r4b/hooks/use-fhir-read.tsx
+++ b/packages/query/src/r4b/hooks/use-fhir-read.tsx
@@ -43,7 +43,7 @@ export function useFhirRead<
   TResourceType extends AnyResourceTypeOrCustomResource,
 >(
   type: TResourceType,
-  id: string | Reference,
+  id: string | Reference | null | undefined,
   options?: UseFhirReadOptions<TResourceType> | null | undefined,
 ): UseQueryResult<Retrieved<ResourceOf<TResourceType>>> {
   const fhirQueryContext = useFhirClientQueryContext(options?.fhirClient);
@@ -51,6 +51,9 @@ export function useFhirRead<
   return useQuery<Retrieved<ResourceOf<TResourceType>>>({
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     ...(options?.query as any),
+    enabled:
+      Boolean(id) &&
+      (options?.query?.enabled == undefined || options?.query?.enabled),
     queryKey: FhirQueryKeys.read(
       fhirQueryContext.clientKey,
       type,

--- a/packages/query/src/r4b/hooks/use-fhir-vread.tsx
+++ b/packages/query/src/r4b/hooks/use-fhir-vread.tsx
@@ -1,8 +1,10 @@
 import {
   AnyResourceTypeOrCustomResource,
   FhirClient,
+  Reference,
   ResourceOf,
   Retrieved,
+  id as resolveId,
 } from "@bonfhir/core/r4b";
 import {
   UseQueryOptions,
@@ -41,8 +43,8 @@ export function useFhirVRead<
   TResourceType extends AnyResourceTypeOrCustomResource,
 >(
   type: TResourceType,
-  id: string,
-  vid: string,
+  id: string | Reference | null | undefined,
+  vid: string | null | undefined,
   options?: UseFhirVReadOptions<TResourceType> | null | undefined,
 ): UseQueryResult<Retrieved<ResourceOf<TResourceType>>> {
   const fhirQueryContext = useFhirClientQueryContext(options?.fhirClient);
@@ -50,15 +52,19 @@ export function useFhirVRead<
   return useQuery<Retrieved<ResourceOf<TResourceType>>>({
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     ...(options?.query as any),
+    enabled:
+      Boolean(id) &&
+      Boolean(vid) &&
+      (options?.query?.enabled == undefined || options?.query?.enabled),
     queryKey: FhirQueryKeys.vread(
       fhirQueryContext.clientKey,
       type,
-      id,
-      vid,
+      resolveId(id) || "",
+      vid || "",
       options?.fhir,
     ),
     queryFn: ({ signal }) =>
-      fhirQueryContext.fhirClient.vread(type, id, vid, {
+      fhirQueryContext.fhirClient.vread(type, resolveId(id) || "", vid || "", {
         ...options?.fhir,
         signal,
       }),

--- a/packages/query/src/r4b/index.test.tsx
+++ b/packages/query/src/r4b/index.test.tsx
@@ -441,6 +441,16 @@ describe("hooks", () => {
       });
     });
 
+    it("disable read on empty ids", async () => {
+      const { result } = renderHook(() => useFhirRead("Patient", undefined), {
+        wrapper,
+      });
+
+      await waitFor(() => {
+        expect(result.current.isFetching).toBeFalsy();
+      });
+    });
+
     it("vread", async () => {
       const { result } = renderHook(
         () =>
@@ -471,6 +481,18 @@ describe("hooks", () => {
       await waitFor(() => {
         expect(result.current.isSuccess).toBeTruthy();
         expect(result.current.data).toBeInstanceOf(CustomPatient);
+      });
+    });
+
+    it("disable vread on empty ids", async () => {
+      const { result } = renderHook(
+        () =>
+          useFhirVRead("Patient", "a942b3d5-19bc-4959-8b5d-f9aedd790a94", ""),
+        { wrapper },
+      );
+
+      await waitFor(() => {
+        expect(result.current.isSuccess).toBeFalsy();
       });
     });
 

--- a/packages/query/src/r5/hooks/use-fhir-read.tsx
+++ b/packages/query/src/r5/hooks/use-fhir-read.tsx
@@ -43,7 +43,7 @@ export function useFhirRead<
   TResourceType extends AnyResourceTypeOrCustomResource,
 >(
   type: TResourceType,
-  id: string | Reference,
+  id: string | Reference | null | undefined,
   options?: UseFhirReadOptions<TResourceType> | null | undefined,
 ): UseQueryResult<Retrieved<ResourceOf<TResourceType>>> {
   const fhirQueryContext = useFhirClientQueryContext(options?.fhirClient);
@@ -51,6 +51,9 @@ export function useFhirRead<
   return useQuery<Retrieved<ResourceOf<TResourceType>>>({
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     ...(options?.query as any),
+    enabled:
+      Boolean(id) &&
+      (options?.query?.enabled == undefined || options?.query?.enabled),
     queryKey: FhirQueryKeys.read(
       fhirQueryContext.clientKey,
       type,

--- a/packages/query/src/r5/hooks/use-fhir-vread.tsx
+++ b/packages/query/src/r5/hooks/use-fhir-vread.tsx
@@ -1,8 +1,10 @@
 import {
   AnyResourceTypeOrCustomResource,
   FhirClient,
+  Reference,
   ResourceOf,
   Retrieved,
+  id as resolveId,
 } from "@bonfhir/core/r5";
 import {
   UseQueryOptions,
@@ -41,8 +43,8 @@ export function useFhirVRead<
   TResourceType extends AnyResourceTypeOrCustomResource,
 >(
   type: TResourceType,
-  id: string,
-  vid: string,
+  id: string | Reference | null | undefined,
+  vid: string | null | undefined,
   options?: UseFhirVReadOptions<TResourceType> | null | undefined,
 ): UseQueryResult<Retrieved<ResourceOf<TResourceType>>> {
   const fhirQueryContext = useFhirClientQueryContext(options?.fhirClient);
@@ -50,15 +52,19 @@ export function useFhirVRead<
   return useQuery<Retrieved<ResourceOf<TResourceType>>>({
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     ...(options?.query as any),
+    enabled:
+      Boolean(id) &&
+      Boolean(vid) &&
+      (options?.query?.enabled == undefined || options?.query?.enabled),
     queryKey: FhirQueryKeys.vread(
       fhirQueryContext.clientKey,
       type,
-      id,
-      vid,
+      resolveId(id) || "",
+      vid || "",
       options?.fhir,
     ),
     queryFn: ({ signal }) =>
-      fhirQueryContext.fhirClient.vread(type, id, vid, {
+      fhirQueryContext.fhirClient.vread(type, resolveId(id) || "", vid || "", {
         ...options?.fhir,
         signal,
       }),

--- a/packages/query/src/r5/index.test.tsx
+++ b/packages/query/src/r5/index.test.tsx
@@ -441,6 +441,16 @@ describe("hooks", () => {
       });
     });
 
+    it("disable read on empty ids", async () => {
+      const { result } = renderHook(() => useFhirRead("Patient", undefined), {
+        wrapper,
+      });
+
+      await waitFor(() => {
+        expect(result.current.isFetching).toBeFalsy();
+      });
+    });
+
     it("vread", async () => {
       const { result } = renderHook(
         () =>
@@ -471,6 +481,18 @@ describe("hooks", () => {
       await waitFor(() => {
         expect(result.current.isSuccess).toBeTruthy();
         expect(result.current.data).toBeInstanceOf(CustomPatient);
+      });
+    });
+
+    it("disable vread on empty ids", async () => {
+      const { result } = renderHook(
+        () =>
+          useFhirVRead("Patient", "a942b3d5-19bc-4959-8b5d-f9aedd790a94", ""),
+        { wrapper },
+      );
+
+      await waitFor(() => {
+        expect(result.current.isSuccess).toBeFalsy();
       });
     });
 


### PR DESCRIPTION
This makes working with async router a lot easier.

Fix #140