### PR TITLE
Fix bugs in `@bonfhir/query`

### DIFF
--- a/.changeset/dry-coats-breathe.md
+++ b/.changeset/dry-coats-breathe.md
@@ -1,0 +1,5 @@
+---
+"@bonfhir/query": patch
+---
+
+Fix #203: using `useFhirGraphQLMutation` with a typed document and options result in an error

--- a/.changeset/gold-planets-grab.md
+++ b/.changeset/gold-planets-grab.md
@@ -1,0 +1,7 @@
+---
+"@bonfhir/query": patch
+---
+
+Rename `UseFhirGraph` to `useFhirGraph` (improper casing)
+
+This is technically a breaking change, but should be trivial to resolve and I don't think many implementations use it.

--- a/packages/query/src/r4b/hooks/use-fhir-graph.tsx
+++ b/packages/query/src/r4b/hooks/use-fhir-graph.tsx
@@ -38,7 +38,7 @@ export interface UseFhirGraphOptions<
  *
  * @see http://hl7.org/fhir/R4B/resource-operation-graph.html
  */
-export function UseFhirGraph<
+export function useFhirGraph<
   TResourceType extends AnyResourceTypeOrCustomResource,
 >(
   graph: string,

--- a/packages/query/src/r4b/hooks/use-fhir-graphql-mutation.tsx
+++ b/packages/query/src/r4b/hooks/use-fhir-graphql-mutation.tsx
@@ -76,7 +76,7 @@ export function useFhirGraphQLMutation<
       fhirQueryContext.fhirClient.graphql(
         query as any,
         variables as any,
-        operationName as any,
+        typeof operationName === "string" ? (operationName as any) : undefined,
       ),
   });
 }

--- a/packages/query/src/r4b/hooks/use-fhir-graphql-result.tsx
+++ b/packages/query/src/r4b/hooks/use-fhir-graphql-result.tsx
@@ -81,7 +81,7 @@ export function useFhirGraphQLResult<
       fhirQueryContext.fhirClient.graphqlResult(
         query as any,
         variables as any,
-        operationName as any,
+        typeof operationName === "string" ? (operationName as any) : undefined,
       ),
   });
 }

--- a/packages/query/src/r4b/hooks/use-fhir-graphql.tsx
+++ b/packages/query/src/r4b/hooks/use-fhir-graphql.tsx
@@ -69,7 +69,7 @@ export function useFhirGraphQL<TResult = any, TVariables = Record<string, any>>(
       fhirQueryContext.fhirClient.graphql(
         query as any,
         variables as any,
-        operationName as any,
+        typeof operationName === "string" ? (operationName as any) : undefined,
       ),
   });
 }

--- a/packages/query/src/r4b/index.test.tsx
+++ b/packages/query/src/r4b/index.test.tsx
@@ -22,7 +22,6 @@ import React, { PropsWithChildren } from "react";
 import {
   DEFAULT_FHIR_CLIENT,
   FhirQueryProvider,
-  UseFhirGraph,
   useFhirBatchMutation,
   useFhirCapabilities,
   useFhirClientQueryContext,
@@ -31,6 +30,7 @@ import {
   useFhirDeleteMutation,
   useFhirExecute,
   useFhirExecuteMutation,
+  useFhirGraph,
   useFhirGraphQL,
   useFhirGraphQLMutation,
   useFhirGraphQLResult,
@@ -741,7 +741,7 @@ describe("hooks", () => {
     it("graph", async () => {
       const { result } = renderHook(
         () =>
-          UseFhirGraph(
+          useFhirGraph(
             "patient-with-appointments",
             "Patient",
             "50e500d7-2afd-42a8-adb7-350489ea3e3c",

--- a/packages/query/src/r5/hooks/use-fhir-graph.tsx
+++ b/packages/query/src/r5/hooks/use-fhir-graph.tsx
@@ -38,7 +38,7 @@ export interface UseFhirGraphOptions<
  *
  * @see http://hl7.org/fhir/R4B/resource-operation-graph.html
  */
-export function UseFhirGraph<
+export function useFhirGraph<
   TResourceType extends AnyResourceTypeOrCustomResource,
 >(
   graph: string,

--- a/packages/query/src/r5/hooks/use-fhir-graphql-mutation.tsx
+++ b/packages/query/src/r5/hooks/use-fhir-graphql-mutation.tsx
@@ -76,7 +76,7 @@ export function useFhirGraphQLMutation<
       fhirQueryContext.fhirClient.graphql(
         query as any,
         variables as any,
-        operationName as any,
+        typeof operationName === "string" ? (operationName as any) : undefined,
       ),
   });
 }

--- a/packages/query/src/r5/hooks/use-fhir-graphql-result.tsx
+++ b/packages/query/src/r5/hooks/use-fhir-graphql-result.tsx
@@ -81,7 +81,7 @@ export function useFhirGraphQLResult<
       fhirQueryContext.fhirClient.graphqlResult(
         query as any,
         variables as any,
-        operationName as any,
+        typeof operationName === "string" ? (operationName as any) : undefined,
       ),
   });
 }

--- a/packages/query/src/r5/hooks/use-fhir-graphql.tsx
+++ b/packages/query/src/r5/hooks/use-fhir-graphql.tsx
@@ -69,7 +69,7 @@ export function useFhirGraphQL<TResult = any, TVariables = Record<string, any>>(
       fhirQueryContext.fhirClient.graphql(
         query as any,
         variables as any,
-        operationName as any,
+        typeof operationName === "string" ? (operationName as any) : undefined,
       ),
   });
 }

--- a/packages/query/src/r5/index.test.tsx
+++ b/packages/query/src/r5/index.test.tsx
@@ -22,7 +22,6 @@ import React, { PropsWithChildren } from "react";
 import {
   DEFAULT_FHIR_CLIENT,
   FhirQueryProvider,
-  UseFhirGraph,
   useFhirBatchMutation,
   useFhirCapabilities,
   useFhirClientQueryContext,
@@ -31,6 +30,7 @@ import {
   useFhirDeleteMutation,
   useFhirExecute,
   useFhirExecuteMutation,
+  useFhirGraph,
   useFhirGraphQL,
   useFhirGraphQLMutation,
   useFhirGraphQLResult,
@@ -741,7 +741,7 @@ describe("hooks", () => {
     it("graph", async () => {
       const { result } = renderHook(
         () =>
-          UseFhirGraph(
+          useFhirGraph(
             "patient-with-appointments",
             "Patient",
             "50e500d7-2afd-42a8-adb7-350489ea3e3c",


### PR DESCRIPTION
Fix #203: `useFhirGraphQL`, `useFhirGraphQLResult` and `useFhirGraphQLMutation` all have errors when using a typed document node and options without variables. This fixes it.

This also contains a change: `UseFhirGraph` becomes `useFhirGraph` - the casing was wrong.
This is technically a breaking change, but should be trivial to resolve and I don't think many implementations use it - this the choice to make it a patch change and not a major one.