### PR TITLE
Update formatter types and helpers to make it more adaptable - specifically in GraphQL contexts

### DIFF
--- a/.changeset/rich-goats-glow.md
+++ b/.changeset/rich-goats-glow.md
@@ -1,0 +1,5 @@
+---
+"@bonfhir/core": minor
+---
+
+Update formatter types and helpers to make it more adaptable - specifically in GraphQL contexts (see #132)

--- a/packages/core/src/r4b/builders.ts
+++ b/packages/core/src/r4b/builders.ts
@@ -1,13 +1,11 @@
 import {
   AnyDomainResourceType,
-  AnyResource,
   AnyResourceType,
   CodeableConcept,
   Coding,
   ExtractDomainResource,
   ExtractResource,
   Reference,
-  Retrieved,
 } from "./fhir-types.codegen";
 import { asArray } from "./lang-utils";
 import { narrative } from "./narratives.codegen";
@@ -35,12 +33,25 @@ export function build<TDomainResourceType extends AnyDomainResourceType>(
 /**
  * Returns the id of a resource, a reference, or an id itself.
  */
-export function id(value: Retrieved<AnyResource>): string;
+export function id(value: {
+  resourceType: AnyResourceType;
+  id: string;
+}): string;
 export function id(
-  value: Reference | Retrieved<AnyResource> | string | null | undefined,
+  value:
+    | { reference?: string | undefined }
+    | { resourceType: AnyResourceType; id: string }
+    | string
+    | null
+    | undefined,
 ): string | undefined;
 export function id(
-  value: Reference | Retrieved<AnyResource> | string | null | undefined,
+  value:
+    | { reference?: string | undefined }
+    | { resourceType: AnyResourceType; id: string }
+    | string
+    | null
+    | undefined,
 ): string | undefined {
   if (!value) {
     return undefined;
@@ -50,12 +61,15 @@ export function id(
     return value.trim().split("/").pop() || undefined;
   }
 
-  const valueAsDomainResource = value as Retrieved<AnyResource>;
+  const valueAsDomainResource = value as {
+    resourceType: AnyResourceType;
+    id: string;
+  };
   if (valueAsDomainResource.resourceType) {
     return valueAsDomainResource.id?.split("/").pop() || undefined;
   }
 
-  const valueAsReference = value as Reference;
+  const valueAsReference = value as { reference?: string | undefined };
 
   if (!valueAsReference.reference) {
     return undefined;

--- a/packages/core/src/r4b/lang-utils.ts
+++ b/packages/core/src/r4b/lang-utils.ts
@@ -8,7 +8,6 @@ import {
   AnyResourceType,
   DomainResource,
   ExtractResource,
-  Period,
   Reference,
   Resource,
   isResource,
@@ -244,7 +243,13 @@ export function formatWithTokens(
 }
 
 export interface WithPeriod {
-  period?: Period | undefined;
+  period?:
+    | {
+        start?: string | number | null | undefined;
+        end?: string | number | null | undefined;
+      }
+    | null
+    | undefined;
 }
 
 export function comparePeriods(

--- a/packages/core/src/r4b/value-formatters/age.ts
+++ b/packages/core/src/r4b/value-formatters/age.ts
@@ -1,6 +1,9 @@
-import { Age } from "../fhir-types.codegen";
 import { ValueFormatter } from "../formatters";
-import { QuantityFormatterOptions, quantityFormatter } from "./quantity";
+import {
+  FormattableQuantity,
+  QuantityFormatterOptions,
+  quantityFormatter,
+} from "./quantity";
 
 /**
  * A measured amount (or an amount that can potentially be measured).
@@ -11,7 +14,7 @@ export type AgeFormatterOptions = QuantityFormatterOptions;
 
 export const ageFormatter: ValueFormatter<
   "Age",
-  Age | null | undefined,
+  FormattableQuantity | null | undefined,
   AgeFormatterOptions | null | undefined
 > = {
   type: "Age",

--- a/packages/core/src/r4b/value-formatters/codeable-concept.ts
+++ b/packages/core/src/r4b/value-formatters/codeable-concept.ts
@@ -1,10 +1,13 @@
-import { CodeableConcept } from "../fhir-types.codegen";
 import {
   ValueFormatter,
   cleanUpCommonOptions,
   withValueFormatter,
 } from "../formatters";
-import { CodingFormatterOptions, codingFormatter } from "./coding";
+import {
+  CodingFormatterOptions,
+  FormattableCoding,
+  codingFormatter,
+} from "./coding";
 
 /**
  * A CodeableConcept represents a value that is usually supplied by
@@ -23,9 +26,14 @@ export interface CodeableConceptFormatterOptions
   listFormatOptions?: Intl.ListFormatOptions | undefined;
 }
 
+export interface FormattableCodeableConcept {
+  coding?: Array<FormattableCoding> | null | undefined;
+  text?: string | null | undefined;
+}
+
 export const codeableConceptFormatter: ValueFormatter<
   "CodeableConcept",
-  CodeableConcept | null | undefined,
+  FormattableCodeableConcept | null | undefined,
   CodeableConceptFormatterOptions | null | undefined
 > = {
   type: "CodeableConcept",

--- a/packages/core/src/r4b/value-formatters/coding.ts
+++ b/packages/core/src/r4b/value-formatters/coding.ts
@@ -1,4 +1,3 @@
-import { Coding } from "../fhir-types.codegen";
 import { ValueFormatter, withValueFormatter } from "../formatters";
 import { CodeFormatterOptions, codeFormatter } from "./code";
 
@@ -18,9 +17,16 @@ export interface CodingFormatterOptions {
   expansions?: CodeFormatterOptions["expansions"];
 }
 
+export interface FormattableCoding {
+  code?: string | null | undefined;
+  display?: string | null | undefined;
+  system?: string | null | undefined;
+  userSelected?: boolean | null | undefined;
+}
+
 export const codingFormatter: ValueFormatter<
   "Coding",
-  Coding | null | undefined,
+  FormattableCoding | null | undefined,
   CodingFormatterOptions | null | undefined
 > = {
   type: "Coding",

--- a/packages/core/src/r4b/value-formatters/contact-point.ts
+++ b/packages/core/src/r4b/value-formatters/contact-point.ts
@@ -1,11 +1,15 @@
-import { ContactPoint } from "../fhir-types.codegen";
+import {
+  ContactPoint,
+  ContactPointSystem,
+  ContactPointUse,
+} from "../fhir-types.codegen";
 import {
   ValueFormatter,
   cleanUpCommonOptions,
   withValueFormatter,
 } from "../formatters";
 import { CodeFormatterOptions, codeFormatter } from "./code";
-import { periodFormatter } from "./period";
+import { FormattablePeriod, periodFormatter } from "./period";
 
 /**
  * Details for all kinds of technology-mediated contact points for a person or organization, including telephone, email, etc.
@@ -51,9 +55,17 @@ export interface ContactPointFormatterOptions {
   useExpansions?: CodeFormatterOptions["expansions"];
 }
 
+export interface FormattableContactPoint {
+  period?: FormattablePeriod | null | undefined;
+  rank?: number | null | undefined;
+  system?: ContactPointSystem | null | undefined;
+  use?: ContactPointUse | null | undefined;
+  value?: string | null | undefined;
+}
+
 export const contactPointFormatter: ValueFormatter<
   "ContactPoint",
-  ContactPoint | ContactPoint[] | null | undefined,
+  FormattableContactPoint | FormattableContactPoint[] | null | undefined,
   ContactPointFormatterOptions | null | undefined
 > = {
   type: "ContactPoint",
@@ -118,9 +130,9 @@ export const contactPointFormatter: ValueFormatter<
 };
 
 function filterAndSortContactPoints(
-  contactPoints: ContactPoint[],
+  contactPoints: FormattableContactPoint[],
   options: ContactPointFormatterOptions | null | undefined,
-): ContactPoint[] {
+) {
   const useFilterOrder =
     options?.useFilterOrder || DEFAULT_CONTACT_POINT_USE_ORDER_FILTER;
   const indexedOrder: { [k: string]: number } = Object.fromEntries(
@@ -133,7 +145,7 @@ function filterAndSortContactPoints(
   // filter out by use
   if (options?.useFilterOrder)
     contactPoints = contactPoints.filter((contactPoint) =>
-      useFilterOrder.includes(contactPoint.use),
+      useFilterOrder.includes(contactPoint.use ?? undefined),
     );
 
   contactPoints = contactPoints.sort((contactPoint1, contactPoint2) => {
@@ -161,7 +173,7 @@ function filterAndSortContactPoints(
   return contactPoints;
 }
 
-const DEFAULT_CONTACT_POINT_USE_ORDER_FILTER = [
+const DEFAULT_CONTACT_POINT_USE_ORDER_FILTER: ContactPoint["use"][] = [
   "home",
   "work",
   "temp",

--- a/packages/core/src/r4b/value-formatters/count.ts
+++ b/packages/core/src/r4b/value-formatters/count.ts
@@ -1,6 +1,9 @@
-import { Count } from "../fhir-types.codegen";
 import { ValueFormatter } from "../formatters";
-import { QuantityFormatterOptions, quantityFormatter } from "./quantity";
+import {
+  FormattableQuantity,
+  QuantityFormatterOptions,
+  quantityFormatter,
+} from "./quantity";
 
 /**
  * A measured amount (or an amount that can potentially be measured).
@@ -11,7 +14,7 @@ export type CountFormatterOptions = QuantityFormatterOptions;
 
 export const countFormatter: ValueFormatter<
   "Count",
-  Count | null | undefined,
+  FormattableQuantity | null | undefined,
   CountFormatterOptions | null | undefined
 > = {
   type: "Count",

--- a/packages/core/src/r4b/value-formatters/distance.ts
+++ b/packages/core/src/r4b/value-formatters/distance.ts
@@ -1,6 +1,9 @@
-import { Distance } from "../fhir-types.codegen";
 import { ValueFormatter } from "../formatters";
-import { QuantityFormatterOptions, quantityFormatter } from "./quantity";
+import {
+  FormattableQuantity,
+  QuantityFormatterOptions,
+  quantityFormatter,
+} from "./quantity";
 
 /**
  * A measured amount (or an amount that can potentially be measured).
@@ -11,7 +14,7 @@ export type DistanceFormatterOptions = QuantityFormatterOptions;
 
 export const distanceFormatter: ValueFormatter<
   "Distance",
-  Distance | null | undefined,
+  FormattableQuantity | null | undefined,
   DistanceFormatterOptions | null | undefined
 > = {
   type: "Distance",

--- a/packages/core/src/r4b/value-formatters/duration.ts
+++ b/packages/core/src/r4b/value-formatters/duration.ts
@@ -1,6 +1,10 @@
-import { Distance, ValueSetExpansionContains } from "../fhir-types.codegen";
+import { ValueSetExpansionContains } from "../fhir-types.codegen";
 import { ValueFormatter } from "../formatters";
-import { QuantityFormatterOptions, quantityFormatter } from "./quantity";
+import {
+  FormattableQuantity,
+  QuantityFormatterOptions,
+  quantityFormatter,
+} from "./quantity";
 
 /**
  * A measured amount (or an amount that can potentially be measured).
@@ -11,7 +15,7 @@ export type DurationFormatterOptions = QuantityFormatterOptions;
 
 export const durationFormatter: ValueFormatter<
   "Duration",
-  Distance | null | undefined,
+  FormattableQuantity | null | undefined,
   DurationFormatterOptions | null | undefined
 > = {
   type: "Duration",

--- a/packages/core/src/r4b/value-formatters/fhirpath.ts
+++ b/packages/core/src/r4b/value-formatters/fhirpath.ts
@@ -2,7 +2,7 @@ import { ValueFormatter } from "../formatters";
 
 export const fhirPathFormatter: ValueFormatter<
   "http://hl7.org/fhirpath/System.String",
-  string,
+  string | null | undefined,
   null | undefined
 > = {
   type: "http://hl7.org/fhirpath/System.String",

--- a/packages/core/src/r4b/value-formatters/human-name.ts
+++ b/packages/core/src/r4b/value-formatters/human-name.ts
@@ -1,4 +1,4 @@
-import { periodFormatter } from ".";
+import { FormattablePeriod, periodFormatter } from ".";
 import { formatWithTokens } from "..";
 import { HumanName, NameUse } from "../fhir-types.codegen";
 import {
@@ -82,9 +82,19 @@ export interface HumanNameFormatterOptions {
   expansions?: CodeFormatterOptions["expansions"];
 }
 
+export interface FormattableHumanName {
+  family?: string | null | undefined;
+  given?: string[] | null | undefined;
+  period?: FormattablePeriod | null | undefined;
+  prefix?: string[] | null | undefined;
+  suffix?: string[] | null | undefined;
+  text?: string | null | undefined;
+  use?: NameUse | null | undefined;
+}
+
 export const humanNameFormatter: ValueFormatter<
   "HumanName",
-  HumanName | HumanName[] | null | undefined,
+  FormattableHumanName | FormattableHumanName[] | null | undefined,
   HumanNameFormatterOptions | null | undefined
 > = {
   type: "HumanName",
@@ -140,7 +150,7 @@ export const humanNameFormatter: ValueFormatter<
       }).replaceAll(/\s+/g, " ");
     }
 
-    let nameComponents: Array<string | undefined>;
+    let nameComponents: Array<string | null | undefined>;
 
     switch (options?.style) {
       case "full": {
@@ -202,10 +212,10 @@ export const humanNameFormatter: ValueFormatter<
   },
 };
 
-const filterAndSortHumanNames = (
-  humanNames: HumanName[],
+function filterAndSortHumanNames(
+  humanNames: FormattableHumanName[],
   options: HumanNameFormatterOptions | null | undefined,
-): HumanName[] => {
+) {
   const useFilterOrder =
     options?.useFilterOrder || DEFAULT_HUMAN_NAME_USE_ORDER_FILTER;
   const indexedOrder: { [k: string]: number } = Object.fromEntries(
@@ -218,7 +228,7 @@ const filterAndSortHumanNames = (
   // filter out by use
   if (options?.useFilterOrder)
     humanNames = humanNames.filter((humanName) =>
-      useFilterOrder.includes(humanName.use),
+      useFilterOrder.includes(humanName.use ?? undefined),
     );
 
   // sort by use
@@ -234,7 +244,7 @@ const filterAndSortHumanNames = (
   }
 
   return humanNames;
-};
+}
 
 const DEFAULT_HUMAN_NAME_USE_ORDER_FILTER: HumanName["use"][] = [
   "official",

--- a/packages/core/src/r4b/value-formatters/id.ts
+++ b/packages/core/src/r4b/value-formatters/id.ts
@@ -1,6 +1,10 @@
 import { ValueFormatter } from "../formatters";
 
-export const idFormatter: ValueFormatter<"id", string, null | undefined> = {
+export const idFormatter: ValueFormatter<
+  "id",
+  string | null | undefined,
+  null | undefined
+> = {
   type: "id",
   format: (value) => {
     return value?.trim() || "";

--- a/packages/core/src/r4b/value-formatters/money.ts
+++ b/packages/core/src/r4b/value-formatters/money.ts
@@ -1,4 +1,4 @@
-import { Money } from "../fhir-types.codegen";
+import { Currencies } from "../fhir-types.codegen";
 import { ValueFormatter } from "../formatters";
 
 /**
@@ -32,9 +32,14 @@ export type MoneyFormatterOptions = {
     | undefined;
 };
 
+export interface FormattableMoney {
+  currency?: Currencies | null | undefined;
+  value?: number | null | undefined;
+}
+
 export const moneyFormatter: ValueFormatter<
   "Money",
-  Money | null | undefined,
+  FormattableMoney | null | undefined,
   MoneyFormatterOptions | null | undefined
 > = {
   type: "Money",
@@ -43,7 +48,7 @@ export const moneyFormatter: ValueFormatter<
 
     const intlOptions: Intl.NumberFormatOptions = {
       style: "currency",
-      currency: value.currency,
+      currency: value.currency ?? undefined,
     };
 
     intlOptions.currencyDisplay = options?.currencyDisplay;

--- a/packages/core/src/r4b/value-formatters/oid.ts
+++ b/packages/core/src/r4b/value-formatters/oid.ts
@@ -1,6 +1,10 @@
 import { ValueFormatter } from "../formatters";
 
-export const oidFormatter: ValueFormatter<"oid", string, null | undefined> = {
+export const oidFormatter: ValueFormatter<
+  "oid",
+  string | null | undefined,
+  null | undefined
+> = {
   type: "oid",
   format: (value) => {
     return value?.trim() || "";

--- a/packages/core/src/r4b/value-formatters/period.ts
+++ b/packages/core/src/r4b/value-formatters/period.ts
@@ -1,5 +1,4 @@
 import { parseFhirDateTime } from "../date-time-helpers";
-import { Period } from "../fhir-types.codegen";
 import {
   ValueFormatter,
   cleanUpCommonOptions,
@@ -12,9 +11,14 @@ export type PeriodFormatterOptions = DatetimeFormatterOptions & {
   avoidDateDuplication?: boolean;
 };
 
+export interface FormattablePeriod {
+  end?: string | null | undefined;
+  start?: string | null | undefined;
+}
+
 export const periodFormatter: ValueFormatter<
   "Period",
-  Period | null | undefined,
+  FormattablePeriod | null | undefined,
   PeriodFormatterOptions | null | undefined
 > = {
   type: "Period",

--- a/packages/core/src/r4b/value-formatters/quantity.ts
+++ b/packages/core/src/r4b/value-formatters/quantity.ts
@@ -1,4 +1,4 @@
-import { Quantity } from "../fhir-types.codegen";
+import { QuantityComparator } from "../fhir-types.codegen";
 import { ValueFormatter, withValueFormatter } from "../formatters";
 import { CodeFormatterOptions, codeFormatter } from "./code";
 import { DecimalFormatterOptions, decimalFormatter } from "./decimal";
@@ -23,9 +23,16 @@ export interface QuantityFormatterOptions {
   separator?: string | null | undefined;
 }
 
+export interface FormattableQuantity {
+  code?: string | null | undefined;
+  comparator?: QuantityComparator | null | undefined;
+  unit?: string | null | undefined;
+  value?: number | null | undefined;
+}
+
 export const quantityFormatter: ValueFormatter<
   "Quantity",
-  Quantity | null | undefined,
+  FormattableQuantity | null | undefined,
   QuantityFormatterOptions | null | undefined
 > = {
   type: "Quantity",

--- a/packages/core/src/r4b/value-formatters/range.ts
+++ b/packages/core/src/r4b/value-formatters/range.ts
@@ -1,8 +1,11 @@
-import { Range } from "../fhir-types.codegen";
 import { ValueFormatter, withValueFormatter } from "../formatters";
 import { CodeFormatterOptions } from "./code";
 import { DecimalFormatterOptions, decimalFormatter } from "./decimal";
-import { QuantityFormatterOptions, quantityFormatter } from "./quantity";
+import {
+  FormattableQuantity,
+  QuantityFormatterOptions,
+  quantityFormatter,
+} from "./quantity";
 
 /**
  * A set of ordered Quantity values defined by a low and high limit.
@@ -20,9 +23,14 @@ export type RangeFormatterOptions = {
   rangeSeparator?: string | null | undefined;
 };
 
+export interface FormattableRange {
+  high?: FormattableQuantity | null | undefined;
+  low?: FormattableQuantity | null | undefined;
+}
+
 export const rangeFormatter: ValueFormatter<
   "Range",
-  Range | null | undefined,
+  FormattableRange | null | undefined,
   RangeFormatterOptions | null | undefined
 > = {
   type: "Range",

--- a/packages/core/src/r4b/value-formatters/ratio-range.ts
+++ b/packages/core/src/r4b/value-formatters/ratio-range.ts
@@ -4,9 +4,12 @@
  * @see https://hl7.org/fhir/datatypes.html#RatioRange
  */
 
-import { RatioRange } from "../fhir-types.codegen";
 import { ValueFormatter, withValueFormatter } from "../formatters";
-import { QuantityFormatterOptions, quantityFormatter } from "./quantity";
+import {
+  FormattableQuantity,
+  QuantityFormatterOptions,
+  quantityFormatter,
+} from "./quantity";
 import { RangeFormatterOptions, rangeFormatter } from "./range";
 
 export type RatioRangeFormatterOptions = {
@@ -32,9 +35,15 @@ export type RatioRangeFormatterOptions = {
   reduceSingleDenominator?: boolean | null | undefined;
 };
 
+export interface FormattableRatioRange {
+  denominator?: FormattableQuantity | null | undefined;
+  highNumerator?: FormattableQuantity | null | undefined;
+  lowNumerator?: FormattableQuantity | null | undefined;
+}
+
 export const ratioRangeFormatter: ValueFormatter<
   "RatioRange",
-  RatioRange | null | undefined,
+  FormattableRatioRange | null | undefined,
   RatioRangeFormatterOptions | null | undefined
 > = {
   type: "RatioRange",

--- a/packages/core/src/r4b/value-formatters/ratio.ts
+++ b/packages/core/src/r4b/value-formatters/ratio.ts
@@ -1,7 +1,10 @@
-import { Ratio } from "../fhir-types.codegen";
 import { ValueFormatter, withValueFormatter } from "../formatters";
 import { codeFormatter } from "./code";
-import { QuantityFormatterOptions, quantityFormatter } from "./quantity";
+import {
+  FormattableQuantity,
+  QuantityFormatterOptions,
+  quantityFormatter,
+} from "./quantity";
 
 /**
  * A relationship between two Quantity values expressed as a numerator and a denominator.
@@ -29,9 +32,14 @@ export interface RatioFormatterOptions {
   reduceSingleDenominator?: boolean | null | undefined;
 }
 
+export interface FormattableRatio {
+  denominator?: FormattableQuantity | null | undefined;
+  numerator?: FormattableQuantity | null | undefined;
+}
+
 export const ratioFormatter: ValueFormatter<
   "Ratio",
-  Ratio | null | undefined,
+  FormattableRatio | null | undefined,
   RatioFormatterOptions | null | undefined
 > = {
   type: "Ratio",

--- a/packages/core/src/r4b/value-formatters/reference.ts
+++ b/packages/core/src/r4b/value-formatters/reference.ts
@@ -1,10 +1,15 @@
-import { Reference } from "../fhir-types.codegen";
 import { ValueFormatter, withValueFormatter } from "../formatters";
-import { identifierFormatter } from "./identifier";
+import { FormattableIdentifier, identifierFormatter } from "./identifier";
+
+export interface FormattableReference {
+  display?: string | null | undefined;
+  identifier?: FormattableIdentifier | null | undefined;
+  reference?: string | null | undefined;
+}
 
 export const referenceFormatter: ValueFormatter<
   "Reference",
-  Reference | null | undefined,
+  FormattableReference | null | undefined,
   null | undefined
 > = {
   type: "Reference",

--- a/packages/core/src/r5/builders.ts
+++ b/packages/core/src/r5/builders.ts
@@ -1,13 +1,11 @@
 import {
   AnyDomainResourceType,
-  AnyResource,
   AnyResourceType,
   CodeableConcept,
   Coding,
   ExtractDomainResource,
   ExtractResource,
   Reference,
-  Retrieved,
 } from "./fhir-types.codegen";
 import { asArray } from "./lang-utils";
 import { narrative } from "./narratives.codegen";
@@ -35,12 +33,25 @@ export function build<TDomainResourceType extends AnyDomainResourceType>(
 /**
  * Returns the id of a resource, a reference, or an id itself.
  */
-export function id(value: Retrieved<AnyResource>): string;
+export function id(value: {
+  resourceType: AnyResourceType;
+  id: string;
+}): string;
 export function id(
-  value: Reference | Retrieved<AnyResource> | string | null | undefined,
+  value:
+    | { reference?: string | undefined }
+    | { resourceType: AnyResourceType; id: string }
+    | string
+    | null
+    | undefined,
 ): string | undefined;
 export function id(
-  value: Reference | Retrieved<AnyResource> | string | null | undefined,
+  value:
+    | { reference?: string | undefined }
+    | { resourceType: AnyResourceType; id: string }
+    | string
+    | null
+    | undefined,
 ): string | undefined {
   if (!value) {
     return undefined;
@@ -50,12 +61,15 @@ export function id(
     return value.trim().split("/").pop() || undefined;
   }
 
-  const valueAsDomainResource = value as Retrieved<AnyResource>;
+  const valueAsDomainResource = value as {
+    resourceType: AnyResourceType;
+    id: string;
+  };
   if (valueAsDomainResource.resourceType) {
     return valueAsDomainResource.id?.split("/").pop() || undefined;
   }
 
-  const valueAsReference = value as Reference;
+  const valueAsReference = value as { reference?: string | undefined };
 
   if (!valueAsReference.reference) {
     return undefined;

--- a/packages/core/src/r5/lang-utils.ts
+++ b/packages/core/src/r5/lang-utils.ts
@@ -8,7 +8,6 @@ import {
   AnyResourceType,
   DomainResource,
   ExtractResource,
-  Period,
   Reference,
   Resource,
   isResource,
@@ -244,7 +243,13 @@ export function formatWithTokens(
 }
 
 export interface WithPeriod {
-  period?: Period | undefined;
+  period?:
+    | {
+        start?: string | number | null | undefined;
+        end?: string | number | null | undefined;
+      }
+    | null
+    | undefined;
 }
 
 export function comparePeriods(

--- a/packages/core/src/r5/value-formatters/age.ts
+++ b/packages/core/src/r5/value-formatters/age.ts
@@ -1,6 +1,9 @@
-import { Age } from "../fhir-types.codegen";
 import { ValueFormatter } from "../formatters";
-import { QuantityFormatterOptions, quantityFormatter } from "./quantity";
+import {
+  FormattableQuantity,
+  QuantityFormatterOptions,
+  quantityFormatter,
+} from "./quantity";
 
 /**
  * A measured amount (or an amount that can potentially be measured).
@@ -11,7 +14,7 @@ export type AgeFormatterOptions = QuantityFormatterOptions;
 
 export const ageFormatter: ValueFormatter<
   "Age",
-  Age | null | undefined,
+  FormattableQuantity | null | undefined,
   AgeFormatterOptions | null | undefined
 > = {
   type: "Age",

--- a/packages/core/src/r5/value-formatters/codeable-concept.ts
+++ b/packages/core/src/r5/value-formatters/codeable-concept.ts
@@ -1,10 +1,13 @@
-import { CodeableConcept } from "../fhir-types.codegen";
 import {
   ValueFormatter,
   cleanUpCommonOptions,
   withValueFormatter,
 } from "../formatters";
-import { CodingFormatterOptions, codingFormatter } from "./coding";
+import {
+  CodingFormatterOptions,
+  FormattableCoding,
+  codingFormatter,
+} from "./coding";
 
 /**
  * A CodeableConcept represents a value that is usually supplied by
@@ -23,9 +26,14 @@ export interface CodeableConceptFormatterOptions
   listFormatOptions?: Intl.ListFormatOptions | undefined;
 }
 
+export interface FormattableCodeableConcept {
+  coding?: Array<FormattableCoding> | null | undefined;
+  text?: string | null | undefined;
+}
+
 export const codeableConceptFormatter: ValueFormatter<
   "CodeableConcept",
-  CodeableConcept | null | undefined,
+  FormattableCodeableConcept | null | undefined,
   CodeableConceptFormatterOptions | null | undefined
 > = {
   type: "CodeableConcept",

--- a/packages/core/src/r5/value-formatters/coding.ts
+++ b/packages/core/src/r5/value-formatters/coding.ts
@@ -1,4 +1,3 @@
-import { Coding } from "../fhir-types.codegen";
 import { ValueFormatter, withValueFormatter } from "../formatters";
 import { CodeFormatterOptions, codeFormatter } from "./code";
 
@@ -18,9 +17,16 @@ export interface CodingFormatterOptions {
   expansions?: CodeFormatterOptions["expansions"];
 }
 
+export interface FormattableCoding {
+  code?: string | null | undefined;
+  display?: string | null | undefined;
+  system?: string | null | undefined;
+  userSelected?: boolean | null | undefined;
+}
+
 export const codingFormatter: ValueFormatter<
   "Coding",
-  Coding | null | undefined,
+  FormattableCoding | null | undefined,
   CodingFormatterOptions | null | undefined
 > = {
   type: "Coding",

--- a/packages/core/src/r5/value-formatters/contact-point.ts
+++ b/packages/core/src/r5/value-formatters/contact-point.ts
@@ -1,11 +1,15 @@
-import { ContactPoint } from "../fhir-types.codegen";
+import {
+  ContactPoint,
+  ContactPointSystem,
+  ContactPointUse,
+} from "../fhir-types.codegen";
 import {
   ValueFormatter,
   cleanUpCommonOptions,
   withValueFormatter,
 } from "../formatters";
 import { CodeFormatterOptions, codeFormatter } from "./code";
-import { periodFormatter } from "./period";
+import { FormattablePeriod, periodFormatter } from "./period";
 
 /**
  * Details for all kinds of technology-mediated contact points for a person or organization, including telephone, email, etc.
@@ -51,9 +55,17 @@ export interface ContactPointFormatterOptions {
   useExpansions?: CodeFormatterOptions["expansions"];
 }
 
+export interface FormattableContactPoint {
+  period?: FormattablePeriod | null | undefined;
+  rank?: number | null | undefined;
+  system?: ContactPointSystem | null | undefined;
+  use?: ContactPointUse | null | undefined;
+  value?: string | null | undefined;
+}
+
 export const contactPointFormatter: ValueFormatter<
   "ContactPoint",
-  ContactPoint | ContactPoint[] | null | undefined,
+  FormattableContactPoint | FormattableContactPoint[] | null | undefined,
   ContactPointFormatterOptions | null | undefined
 > = {
   type: "ContactPoint",
@@ -118,9 +130,9 @@ export const contactPointFormatter: ValueFormatter<
 };
 
 function filterAndSortContactPoints(
-  contactPoints: ContactPoint[],
+  contactPoints: FormattableContactPoint[],
   options: ContactPointFormatterOptions | null | undefined,
-): ContactPoint[] {
+) {
   const useFilterOrder =
     options?.useFilterOrder || DEFAULT_CONTACT_POINT_USE_ORDER_FILTER;
   const indexedOrder: { [k: string]: number } = Object.fromEntries(
@@ -133,7 +145,7 @@ function filterAndSortContactPoints(
   // filter out by use
   if (options?.useFilterOrder)
     contactPoints = contactPoints.filter((contactPoint) =>
-      useFilterOrder.includes(contactPoint.use),
+      useFilterOrder.includes(contactPoint.use ?? undefined),
     );
 
   contactPoints = contactPoints.sort((contactPoint1, contactPoint2) => {
@@ -161,7 +173,7 @@ function filterAndSortContactPoints(
   return contactPoints;
 }
 
-const DEFAULT_CONTACT_POINT_USE_ORDER_FILTER = [
+const DEFAULT_CONTACT_POINT_USE_ORDER_FILTER: ContactPoint["use"][] = [
   "home",
   "work",
   "temp",

--- a/packages/core/src/r5/value-formatters/count.ts
+++ b/packages/core/src/r5/value-formatters/count.ts
@@ -1,6 +1,9 @@
-import { Count } from "../fhir-types.codegen";
 import { ValueFormatter } from "../formatters";
-import { QuantityFormatterOptions, quantityFormatter } from "./quantity";
+import {
+  FormattableQuantity,
+  QuantityFormatterOptions,
+  quantityFormatter,
+} from "./quantity";
 
 /**
  * A measured amount (or an amount that can potentially be measured).
@@ -11,7 +14,7 @@ export type CountFormatterOptions = QuantityFormatterOptions;
 
 export const countFormatter: ValueFormatter<
   "Count",
-  Count | null | undefined,
+  FormattableQuantity | null | undefined,
   CountFormatterOptions | null | undefined
 > = {
   type: "Count",

--- a/packages/core/src/r5/value-formatters/distance.ts
+++ b/packages/core/src/r5/value-formatters/distance.ts
@@ -1,6 +1,9 @@
-import { Distance } from "../fhir-types.codegen";
 import { ValueFormatter } from "../formatters";
-import { QuantityFormatterOptions, quantityFormatter } from "./quantity";
+import {
+  FormattableQuantity,
+  QuantityFormatterOptions,
+  quantityFormatter,
+} from "./quantity";
 
 /**
  * A measured amount (or an amount that can potentially be measured).
@@ -11,7 +14,7 @@ export type DistanceFormatterOptions = QuantityFormatterOptions;
 
 export const distanceFormatter: ValueFormatter<
   "Distance",
-  Distance | null | undefined,
+  FormattableQuantity | null | undefined,
   DistanceFormatterOptions | null | undefined
 > = {
   type: "Distance",

--- a/packages/core/src/r5/value-formatters/duration.ts
+++ b/packages/core/src/r5/value-formatters/duration.ts
@@ -1,6 +1,10 @@
-import { Distance, ValueSetExpansionContains } from "../fhir-types.codegen";
+import { ValueSetExpansionContains } from "../fhir-types.codegen";
 import { ValueFormatter } from "../formatters";
-import { QuantityFormatterOptions, quantityFormatter } from "./quantity";
+import {
+  FormattableQuantity,
+  QuantityFormatterOptions,
+  quantityFormatter,
+} from "./quantity";
 
 /**
  * A measured amount (or an amount that can potentially be measured).
@@ -11,7 +15,7 @@ export type DurationFormatterOptions = QuantityFormatterOptions;
 
 export const durationFormatter: ValueFormatter<
   "Duration",
-  Distance | null | undefined,
+  FormattableQuantity | null | undefined,
   DurationFormatterOptions | null | undefined
 > = {
   type: "Duration",

--- a/packages/core/src/r5/value-formatters/fhirpath.ts
+++ b/packages/core/src/r5/value-formatters/fhirpath.ts
@@ -2,7 +2,7 @@ import { ValueFormatter } from "../formatters";
 
 export const fhirPathFormatter: ValueFormatter<
   "http://hl7.org/fhirpath/System.String",
-  string,
+  string | null | undefined,
   null | undefined
 > = {
   type: "http://hl7.org/fhirpath/System.String",

--- a/packages/core/src/r5/value-formatters/human-name.ts
+++ b/packages/core/src/r5/value-formatters/human-name.ts
@@ -1,4 +1,4 @@
-import { periodFormatter } from ".";
+import { FormattablePeriod, periodFormatter } from ".";
 import { formatWithTokens } from "..";
 import { HumanName, NameUse } from "../fhir-types.codegen";
 import {
@@ -82,9 +82,19 @@ export interface HumanNameFormatterOptions {
   expansions?: CodeFormatterOptions["expansions"];
 }
 
+export interface FormattableHumanName {
+  family?: string | null | undefined;
+  given?: string[] | null | undefined;
+  period?: FormattablePeriod | null | undefined;
+  prefix?: string[] | null | undefined;
+  suffix?: string[] | null | undefined;
+  text?: string | null | undefined;
+  use?: NameUse | null | undefined;
+}
+
 export const humanNameFormatter: ValueFormatter<
   "HumanName",
-  HumanName | HumanName[] | null | undefined,
+  FormattableHumanName | FormattableHumanName[] | null | undefined,
   HumanNameFormatterOptions | null | undefined
 > = {
   type: "HumanName",
@@ -140,7 +150,7 @@ export const humanNameFormatter: ValueFormatter<
       }).replaceAll(/\s+/g, " ");
     }
 
-    let nameComponents: Array<string | undefined>;
+    let nameComponents: Array<string | null | undefined>;
 
     switch (options?.style) {
       case "full": {
@@ -202,10 +212,10 @@ export const humanNameFormatter: ValueFormatter<
   },
 };
 
-const filterAndSortHumanNames = (
-  humanNames: HumanName[],
+function filterAndSortHumanNames(
+  humanNames: FormattableHumanName[],
   options: HumanNameFormatterOptions | null | undefined,
-): HumanName[] => {
+) {
   const useFilterOrder =
     options?.useFilterOrder || DEFAULT_HUMAN_NAME_USE_ORDER_FILTER;
   const indexedOrder: { [k: string]: number } = Object.fromEntries(
@@ -218,7 +228,7 @@ const filterAndSortHumanNames = (
   // filter out by use
   if (options?.useFilterOrder)
     humanNames = humanNames.filter((humanName) =>
-      useFilterOrder.includes(humanName.use),
+      useFilterOrder.includes(humanName.use ?? undefined),
     );
 
   // sort by use
@@ -234,7 +244,7 @@ const filterAndSortHumanNames = (
   }
 
   return humanNames;
-};
+}
 
 const DEFAULT_HUMAN_NAME_USE_ORDER_FILTER: HumanName["use"][] = [
   "official",

--- a/packages/core/src/r5/value-formatters/id.ts
+++ b/packages/core/src/r5/value-formatters/id.ts
@@ -1,6 +1,10 @@
 import { ValueFormatter } from "../formatters";
 
-export const idFormatter: ValueFormatter<"id", string, null | undefined> = {
+export const idFormatter: ValueFormatter<
+  "id",
+  string | null | undefined,
+  null | undefined
+> = {
   type: "id",
   format: (value) => {
     return value?.trim() || "";

--- a/packages/core/src/r5/value-formatters/money.ts
+++ b/packages/core/src/r5/value-formatters/money.ts
@@ -1,4 +1,4 @@
-import { Money } from "../fhir-types.codegen";
+import { Currencies } from "../fhir-types.codegen";
 import { ValueFormatter } from "../formatters";
 
 /**
@@ -32,9 +32,14 @@ export type MoneyFormatterOptions = {
     | undefined;
 };
 
+export interface FormattableMoney {
+  currency?: Currencies | null | undefined;
+  value?: number | null | undefined;
+}
+
 export const moneyFormatter: ValueFormatter<
   "Money",
-  Money | null | undefined,
+  FormattableMoney | null | undefined,
   MoneyFormatterOptions | null | undefined
 > = {
   type: "Money",
@@ -43,7 +48,7 @@ export const moneyFormatter: ValueFormatter<
 
     const intlOptions: Intl.NumberFormatOptions = {
       style: "currency",
-      currency: value.currency,
+      currency: value.currency ?? undefined,
     };
 
     intlOptions.currencyDisplay = options?.currencyDisplay;

--- a/packages/core/src/r5/value-formatters/oid.ts
+++ b/packages/core/src/r5/value-formatters/oid.ts
@@ -1,6 +1,10 @@
 import { ValueFormatter } from "../formatters";
 
-export const oidFormatter: ValueFormatter<"oid", string, null | undefined> = {
+export const oidFormatter: ValueFormatter<
+  "oid",
+  string | null | undefined,
+  null | undefined
+> = {
   type: "oid",
   format: (value) => {
     return value?.trim() || "";

--- a/packages/core/src/r5/value-formatters/period.ts
+++ b/packages/core/src/r5/value-formatters/period.ts
@@ -1,5 +1,4 @@
 import { parseFhirDateTime } from "../date-time-helpers";
-import { Period } from "../fhir-types.codegen";
 import {
   ValueFormatter,
   cleanUpCommonOptions,
@@ -12,9 +11,14 @@ export type PeriodFormatterOptions = DatetimeFormatterOptions & {
   avoidDateDuplication?: boolean;
 };
 
+export interface FormattablePeriod {
+  end?: string | null | undefined;
+  start?: string | null | undefined;
+}
+
 export const periodFormatter: ValueFormatter<
   "Period",
-  Period | null | undefined,
+  FormattablePeriod | null | undefined,
   PeriodFormatterOptions | null | undefined
 > = {
   type: "Period",

--- a/packages/core/src/r5/value-formatters/quantity.ts
+++ b/packages/core/src/r5/value-formatters/quantity.ts
@@ -1,4 +1,4 @@
-import { Quantity } from "../fhir-types.codegen";
+import { QuantityComparator } from "../fhir-types.codegen";
 import { ValueFormatter, withValueFormatter } from "../formatters";
 import { CodeFormatterOptions, codeFormatter } from "./code";
 import { DecimalFormatterOptions, decimalFormatter } from "./decimal";
@@ -23,9 +23,16 @@ export interface QuantityFormatterOptions {
   separator?: string | null | undefined;
 }
 
+export interface FormattableQuantity {
+  code?: string | null | undefined;
+  comparator?: QuantityComparator | null | undefined;
+  unit?: string | null | undefined;
+  value?: number | null | undefined;
+}
+
 export const quantityFormatter: ValueFormatter<
   "Quantity",
-  Quantity | null | undefined,
+  FormattableQuantity | null | undefined,
   QuantityFormatterOptions | null | undefined
 > = {
   type: "Quantity",

--- a/packages/core/src/r5/value-formatters/range.ts
+++ b/packages/core/src/r5/value-formatters/range.ts
@@ -1,8 +1,11 @@
-import { Range } from "../fhir-types.codegen";
 import { ValueFormatter, withValueFormatter } from "../formatters";
 import { CodeFormatterOptions } from "./code";
 import { DecimalFormatterOptions, decimalFormatter } from "./decimal";
-import { QuantityFormatterOptions, quantityFormatter } from "./quantity";
+import {
+  FormattableQuantity,
+  QuantityFormatterOptions,
+  quantityFormatter,
+} from "./quantity";
 
 /**
  * A set of ordered Quantity values defined by a low and high limit.
@@ -20,9 +23,14 @@ export type RangeFormatterOptions = {
   rangeSeparator?: string | null | undefined;
 };
 
+export interface FormattableRange {
+  high?: FormattableQuantity | null | undefined;
+  low?: FormattableQuantity | null | undefined;
+}
+
 export const rangeFormatter: ValueFormatter<
   "Range",
-  Range | null | undefined,
+  FormattableRange | null | undefined,
   RangeFormatterOptions | null | undefined
 > = {
   type: "Range",

--- a/packages/core/src/r5/value-formatters/ratio-range.ts
+++ b/packages/core/src/r5/value-formatters/ratio-range.ts
@@ -4,9 +4,12 @@
  * @see https://hl7.org/fhir/datatypes.html#RatioRange
  */
 
-import { RatioRange } from "../fhir-types.codegen";
 import { ValueFormatter, withValueFormatter } from "../formatters";
-import { QuantityFormatterOptions, quantityFormatter } from "./quantity";
+import {
+  FormattableQuantity,
+  QuantityFormatterOptions,
+  quantityFormatter,
+} from "./quantity";
 import { RangeFormatterOptions, rangeFormatter } from "./range";
 
 export type RatioRangeFormatterOptions = {
@@ -32,9 +35,15 @@ export type RatioRangeFormatterOptions = {
   reduceSingleDenominator?: boolean | null | undefined;
 };
 
+export interface FormattableRatioRange {
+  denominator?: FormattableQuantity | null | undefined;
+  highNumerator?: FormattableQuantity | null | undefined;
+  lowNumerator?: FormattableQuantity | null | undefined;
+}
+
 export const ratioRangeFormatter: ValueFormatter<
   "RatioRange",
-  RatioRange | null | undefined,
+  FormattableRatioRange | null | undefined,
   RatioRangeFormatterOptions | null | undefined
 > = {
   type: "RatioRange",

--- a/packages/core/src/r5/value-formatters/ratio.ts
+++ b/packages/core/src/r5/value-formatters/ratio.ts
@@ -1,7 +1,10 @@
-import { Ratio } from "../fhir-types.codegen";
 import { ValueFormatter, withValueFormatter } from "../formatters";
 import { codeFormatter } from "./code";
-import { QuantityFormatterOptions, quantityFormatter } from "./quantity";
+import {
+  FormattableQuantity,
+  QuantityFormatterOptions,
+  quantityFormatter,
+} from "./quantity";
 
 /**
  * A relationship between two Quantity values expressed as a numerator and a denominator.
@@ -29,9 +32,14 @@ export interface RatioFormatterOptions {
   reduceSingleDenominator?: boolean | null | undefined;
 }
 
+export interface FormattableRatio {
+  denominator?: FormattableQuantity | null | undefined;
+  numerator?: FormattableQuantity | null | undefined;
+}
+
 export const ratioFormatter: ValueFormatter<
   "Ratio",
-  Ratio | null | undefined,
+  FormattableRatio | null | undefined,
   RatioFormatterOptions | null | undefined
 > = {
   type: "Ratio",

--- a/packages/core/src/r5/value-formatters/reference.ts
+++ b/packages/core/src/r5/value-formatters/reference.ts
@@ -1,10 +1,15 @@
-import { Reference } from "../fhir-types.codegen";
 import { ValueFormatter, withValueFormatter } from "../formatters";
-import { identifierFormatter } from "./identifier";
+import { FormattableIdentifier, identifierFormatter } from "./identifier";
+
+export interface FormattableReference {
+  display?: string | null | undefined;
+  identifier?: FormattableIdentifier | null | undefined;
+  reference?: string | null | undefined;
+}
 
 export const referenceFormatter: ValueFormatter<
   "Reference",
-  Reference | null | undefined,
+  FormattableReference | null | undefined,
   null | undefined
 > = {
   type: "Reference",


### PR DESCRIPTION
I updated types manipulated by the formatters to:
 - be much narrower (remove properties that are not used by the formatter)
 - accept `null` values in addition to `undefined`

This makes them usable out-f-the-box with default GraphQL type generations and make them more adaptable to different contexts.

Fix #132

