### PR TITLE
Add `useFhirClient` and `useFhirClientMutation`

### DIFF
--- a/.changeset/breezy-bats-deny.md
+++ b/.changeset/breezy-bats-deny.md
@@ -1,0 +1,5 @@
+---
+"@bonfhir/query": minor
+---
+
+Fix #58 - Add a `useFhirClient` query hook

--- a/.changeset/large-ravens-crash.md
+++ b/.changeset/large-ravens-crash.md
@@ -1,0 +1,5 @@
+---
+"@bonfhir/query": minor
+---
+
+Fix #226 - Add a `useFhirClientMutation` hook

--- a/docs/website/packages/query/mutations/use-fhir-client-mutation.md
+++ b/docs/website/packages/query/mutations/use-fhir-client-mutation.md
@@ -7,7 +7,7 @@ description: Execute a series of FHIR operations
 Return a [Mutation](https://tanstack.com/query/latest/docs/react/guides/mutations) with access to the raw [FhirClient](/packages/core/fhir-client).
 
 This is useful when you have a series of operations to execute as part of a single mutation, or if the other [mutation hooks](/packages/query/mutations)
-won't allow you to do what you mean.  
+won't allow you to do what you want.  
 **You should always prefer to use a more precise hook.**
 
 :::warning

--- a/docs/website/packages/query/mutations/use-fhir-client-mutation.md
+++ b/docs/website/packages/query/mutations/use-fhir-client-mutation.md
@@ -1,0 +1,82 @@
+---
+sidebar_position: 9
+title: useFhirClientMutation
+description: Execute a series of FHIR operations
+---
+
+Return a [Mutation](https://tanstack.com/query/latest/docs/react/guides/mutations) with access to the raw [FhirClient](/packages/core/fhir-client).
+
+This is useful when you have a series of operations to execute as part of a single mutation, or if the other [mutation hooks](/packages/query/mutations)
+won't allow you to do what you mean.  
+**You should always prefer to use a more precise hook.**
+
+:::warning
+
+By default, this mutation will invalidate the _entire_ query cache, unless you use the `doNotInvalidateAllQueries` option
+
+:::
+
+### Basic usage
+
+```tsx
+import { Organization, build } from "@bonfhir/core/r4b";
+import { useFhirClientMutation } from "@bonfhir/query/r4b";
+import { Button } from "@mantine/core";
+
+export default function MyComponent() {
+  // The type here is the awaited return type of the `mutate` method below
+  const clientMutation = useFhirClientMutation<[Organization, boolean]>();
+
+  const execute = () => {
+    clientMutation.mutate(async (client) => {
+      return await client.createOr(
+        "return",
+        build("Organization", { name: "Acme, Inc" }),
+      );
+    });
+  };
+
+  return (
+    <Button loading={clientMutation.isPending} onClick={execute}>
+      Create organization if it does not already exist (by its name)
+    </Button>
+  );
+}
+```
+
+### With options
+
+```tsx
+import { DEFAULT_FHIR_CLIENT, useFhirClientMutation } from "@bonfhir/query/r4b";
+
+export default function MyComponent() {
+  const clientMutation = useFhirClientMutation<[Organization, boolean]>({
+    // The name of the FhirClient to use
+    fhirClient: DEFAULT_FHIR_CLIENT,
+
+    // Settings this to true will prevent the mutation from invalidating all queries
+    doNotInvalidateAllQueries: true,
+
+    // React query mutation options
+    mutation: {
+      onSuccess: ([org, wasCreated]) => {
+        if (wasCreated) {
+          notifications.show({
+            title: "Organization created",
+            message: `Created organization ${org.name}`,
+            color: "green",
+          });
+        } else {
+          notifications.show({
+            title: "Organization already exists",
+            message: "Nothing to do here!",
+            color: "blue",
+          });
+        }
+      },
+      onError: (error) => {...}
+    },
+  });
+  // ...
+}
+```

--- a/docs/website/packages/query/mutations/use-fhir-transaction-mutation.md
+++ b/docs/website/packages/query/mutations/use-fhir-transaction-mutation.md
@@ -18,10 +18,10 @@ import { useFhirTransactionMutation } from "@bonfhir/query/r4b";
 import { Button } from "@mantine/core";
 
 export default function MyComponent() {
-  const transactionQuery = useFhirTransactionMutation();
+  const transactionMutation = useFhirTransactionMutation();
 
   const executeTransaction = () => {
-    transactionQuery.mutate((transaction) => {
+    transactionMutation.mutate((transaction) => {
       // The body of the mutate function is a function that can manipulate the transaction builder
       // We see here that we create an Organization, a Practitioner and a PractionerRole in the same transaction
       // with inner references.
@@ -41,7 +41,10 @@ export default function MyComponent() {
   };
 
   return (
-    <Button loading={transactionQuery.isPending} onClick={executeTransaction}>
+    <Button
+      loading={transactionMutation.isPending}
+      onClick={executeTransaction}
+    >
       Create organization and practitioner
     </Button>
   );
@@ -54,7 +57,7 @@ export default function MyComponent() {
 import { DEFAULT_FHIR_CLIENT, useFhirTransactionMutation } from "@bonfhir/query/r4b";
 
 export default function MyComponent() {
-  const transactionQuery = useFhirTransactionMutation({
+  const transactionMutation = useFhirTransactionMutation({
     // The name of the FhirClient to use
     fhirClient: DEFAULT_FHIR_CLIENT,
 

--- a/docs/website/packages/query/queries/use-fhir-client.md
+++ b/docs/website/packages/query/queries/use-fhir-client.md
@@ -1,0 +1,142 @@
+---
+sidebar_position: 10
+title: useFhirClient
+description: Execute a series of FHIR operations
+---
+
+Return a [Query](https://tanstack.com/query/latest/docs/react/guides/queries) with access to the raw [FhirClient](/packages/core/fhir-client).
+
+This is useful when you have a series of operations to execute as part of a single query, or if the other [query hooks](/packages/query/queries)
+won't allow you to do what you want.  
+**You should always prefer to use a more precise hook.**
+
+:::warning
+
+It is your responsibility to ensure that the operations are **read-only**.  
+If they are not, you should use the [`useFhirClientMutation`](/packages/query/mutations/use-fhir-client-mutation) hook instead.
+
+:::
+
+### Basic usage
+
+```tsx
+import { asError } from "@bonfhir/core/r4b";
+import { useFhirClient } from "@bonfhir/query/r4b";
+import { FhirValue } from "@bonfhir/react/r4b";
+import { useSearchParams } from "react-router-dom";
+
+export default function MyComponent() {
+  const [searchParams] = useSearchParams();
+  const patientId = searchParams.get("patientId");
+
+  const clientQuery = useFhirClient(
+    async (client) => {
+      const batch = client.batch();
+      const patient = batch.search("Patient", (search) =>
+        search._id(patientId),
+      );
+      const conditions = batch.search("Condition", (search) =>
+        search.subject(`Patient/${patientId}`),
+      );
+
+      await batch.send();
+
+      return { patient: patient.resource, conditions: conditions.resource };
+    },
+    // This allows you to specify dependencies for your method - they will invalidate the query if changed.
+    [patientId],
+  );
+
+  if (clientQuery.isLoading) {
+    return <div>Loading...</div>;
+  }
+
+  if (clientQuery.isError) {
+    return <div>{asError(clientQuery.error)?.message}</div>;
+  }
+
+  return (
+    <FhirValue
+      type="HumanName"
+      value={clientQuery.data?.patient.searchMatch()[0]?.name}
+    />
+  );
+}
+```
+
+### With `<FhirQueryLoader />`
+
+```tsx
+import { useFhirClient } from "@bonfhir/query/r4b";
+import { FhirQueryLoader, FhirValue } from "@bonfhir/react/r4b";
+import { useSearchParams } from "react-router-dom";
+
+export default function MyComponent() {
+  const [searchParams] = useSearchParams();
+  const patientId = searchParams.get("patientId");
+
+  const clientQuery = useFhirClient(
+    async (client) => {
+      const batch = client.batch();
+      const patient = batch.search("Patient", (search) =>
+        search._id(patientId),
+      );
+      const conditions = batch.search("Condition", (search) =>
+        search.subject(`Patient/${patientId}`),
+      );
+
+      await batch.send();
+
+      return { patient: patient.resource, conditions: conditions.resource };
+    },
+    [patientId],
+  );
+
+  return (
+    <FhirQueryLoader query={clientQuery}>
+      {(result) => (
+        <FhirValue
+          type="HumanName"
+          value={result.patient.searchMatch()[0]?.name}
+        />
+      )}
+    </FhirQueryLoader>
+  );
+}
+```
+
+### With options
+
+```tsx
+import { DEFAULT_FHIR_CLIENT, useFhirClient } from "@bonfhir/query/r4b";
+
+export default function MyComponent() {
+  const clientQuery = useFhirClient(
+    async (client) => {
+      const batch = client.batch();
+      const patient = batch.search("Patient", (search) =>
+        search._id(patientId),
+      );
+      const conditions = batch.search("Condition", (search) =>
+        search.subject(`Patient/${patientId}`),
+      );
+
+      await batch.send();
+
+      return { patient: patient.resource, conditions: conditions.resource };
+    },
+    [patientId],
+    {
+      // The name of the FhirClient to use
+      fhirClient: DEFAULT_FHIR_CLIENT,
+
+      // React query options
+      query: {
+        gcTime: Number.POSITIVE_INFINITY,
+      },
+    },
+  );
+
+  //...
+}
+```

--- a/docs/website/src/pages/index.tsx
+++ b/docs/website/src/pages/index.tsx
@@ -213,6 +213,7 @@ function BatteriesIncluded() {
     {
       title: "Next.js support",
       text: "Create your front-end app and api using Next.js",
+      link: "/docs/build-a-fhir-solution-with-nextjs",
     },
     {
       title: "Custom FHIR resources",

--- a/packages/query/src/r4b/cache-keys.ts
+++ b/packages/query/src/r4b/cache-keys.ts
@@ -129,6 +129,9 @@ export const FhirQueryKeys = {
       operation.parameters,
     ] as const,
 
+  clientFn: (clientKey: string, fn: string, params: unknown[]) =>
+    [clientKey, "client", fn, ...params] as const,
+
   /**
    * Invalidate all queries that might be impacted by a change on a resource.
    */
@@ -159,5 +162,6 @@ export const FhirQueryKeys = {
     queryClient.invalidateQueries({
       queryKey: [clientKey, type, undefined, "execute"],
     });
+    queryClient.invalidateQueries({ queryKey: [clientKey, "client"] });
   },
 };

--- a/packages/query/src/r4b/cache-keys.ts
+++ b/packages/query/src/r4b/cache-keys.ts
@@ -138,6 +138,11 @@ export const FhirQueryKeys = {
     type: AnyResourceType | undefined,
     id: string | undefined,
   ) => {
+    if (!type && !id) {
+      queryClient.invalidateQueries({ queryKey: [clientKey] });
+      return;
+    }
+
     queryClient.invalidateQueries({ queryKey: [clientKey, type, id] });
     queryClient.invalidateQueries({ queryKey: [clientKey, type, "search"] });
     queryClient.invalidateQueries({

--- a/packages/query/src/r4b/hooks/index.ts
+++ b/packages/query/src/r4b/hooks/index.ts
@@ -1,5 +1,6 @@
 export * from "./use-fhir-batch-mutation";
 export * from "./use-fhir-capabilities";
+export * from "./use-fhir-client";
 export * from "./use-fhir-client-mutation";
 export * from "./use-fhir-create-mutation";
 export * from "./use-fhir-create-or-mutation";

--- a/packages/query/src/r4b/hooks/index.ts
+++ b/packages/query/src/r4b/hooks/index.ts
@@ -1,5 +1,6 @@
 export * from "./use-fhir-batch-mutation";
 export * from "./use-fhir-capabilities";
+export * from "./use-fhir-client-mutation";
 export * from "./use-fhir-create-mutation";
 export * from "./use-fhir-create-or-mutation";
 export * from "./use-fhir-delete-mutation";

--- a/packages/query/src/r4b/hooks/use-fhir-client-mutation.tsx
+++ b/packages/query/src/r4b/hooks/use-fhir-client-mutation.tsx
@@ -1,0 +1,69 @@
+import { FhirClient } from "@bonfhir/core/r4b";
+import {
+  UseMutationOptions,
+  UseMutationResult,
+  useMutation,
+} from "@tanstack/react-query";
+import { FhirQueryKeys } from "../cache-keys";
+import { useFhirClientQueryContext } from "../context";
+
+export type UseFhirClientMutationArgs<TResult> = (
+  client: FhirClient,
+) => Promise<TResult>;
+
+export interface UseFhirClientMutationOptions<TResult> {
+  /** The FhirClient key to use to perform the query. */
+  fhirClient?: string | null | undefined;
+  mutation?:
+    | Omit<
+        UseMutationOptions<
+          TResult,
+          unknown,
+          UseFhirClientMutationArgs<TResult>,
+          unknown
+        >,
+        "mutationFn"
+      >
+    | null
+    | undefined;
+  /**
+   * Whether to invalidate all queries that use the same FhirClient.
+   * IF true, you should probably think about doing manual invalidation in the `onSuccess` callback.
+   */
+  doNotInvalidateAllQueries?: boolean;
+}
+
+/**
+ * This hook allows you to perform one or several operations using a FhirClient directly.
+ *
+ * Invoking it will invalidate all queries that use the same FhirClient if `manageCache` is true (the default).
+ */
+export function useFhirClientMutation<TResult = unknown>(
+  options?: UseFhirClientMutationOptions<TResult> | null | undefined,
+): UseMutationResult<
+  TResult,
+  unknown,
+  UseFhirClientMutationArgs<TResult>,
+  unknown
+> {
+  const fhirQueryContext = useFhirClientQueryContext(options?.fhirClient);
+
+  return useMutation({
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    ...(options?.mutation as any),
+    onSuccess: (data, variables, context) => {
+      if (fhirQueryContext.manageCache && !options?.doNotInvalidateAllQueries) {
+        FhirQueryKeys.invalidateQueries(
+          fhirQueryContext.clientKey,
+          fhirQueryContext.queryClient,
+          undefined,
+          undefined,
+        );
+      }
+      options?.mutation?.onSuccess?.(data, variables, context);
+    },
+    mutationFn: async (args) => {
+      return await args(fhirQueryContext.fhirClient);
+    },
+  });
+}

--- a/packages/query/src/r4b/hooks/use-fhir-client.tsx
+++ b/packages/query/src/r4b/hooks/use-fhir-client.tsx
@@ -1,0 +1,47 @@
+import { FhirClient } from "@bonfhir/core/r4b";
+import {
+  UseQueryOptions,
+  UseQueryResult,
+  useQuery,
+} from "@tanstack/react-query";
+import { FhirQueryKeys } from "../cache-keys";
+import { useFhirClientQueryContext } from "../context";
+
+export interface UseFhirClientOptions<TResult> {
+  /** The FhirClient key to use to perform the query. */
+  fhirClient?: string | null | undefined;
+  query?:
+    | Omit<
+        UseQueryOptions<
+          TResult,
+          unknown,
+          TResult,
+          ReturnType<(typeof FhirQueryKeys)["clientFn"]>
+        >,
+        "initialData" | "queryKey" | "queryFn"
+      >
+    | null
+    | undefined;
+}
+
+/**
+ * Return a [Query](https://tanstack.com/query/latest/docs/react/guides/queries) using a FhirClient directly.
+ */
+export function useFhirClient<TResult>(
+  fn: (client: FhirClient) => Promise<TResult>,
+  params?: unknown[],
+  options?: UseFhirClientOptions<TResult> | null | undefined,
+): UseQueryResult<TResult> {
+  const fhirQueryContext = useFhirClientQueryContext(options?.fhirClient);
+
+  return useQuery<TResult>({
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    ...(options?.query as any),
+    queryKey: FhirQueryKeys.clientFn(
+      fhirQueryContext.clientKey,
+      fn.toString(),
+      params || [],
+    ),
+    queryFn: async () => await fn(fhirQueryContext.fhirClient),
+  });
+}

--- a/packages/query/src/r4b/hooks/use-fhir-transaction-mutation.tsx
+++ b/packages/query/src/r4b/hooks/use-fhir-transaction-mutation.tsx
@@ -48,17 +48,19 @@ export function useFhirTransactionMutation(
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     ...(options?.mutation as any),
     onSuccess: (data, variables, context) => {
-      for (const resource of data.futureRequests.map((x) => x.resource)) {
-        if (
-          (resource as Resource).resourceType &&
-          (resource as Retrieved<Resource>).id
-        ) {
-          FhirQueryKeys.invalidateQueries(
-            fhirQueryContext.clientKey,
-            fhirQueryContext.queryClient,
-            (resource as Resource).resourceType,
-            (resource as Retrieved<Resource>).id,
-          );
+      if (fhirQueryContext.manageCache) {
+        for (const resource of data.futureRequests.map((x) => x.resource)) {
+          if (
+            (resource as Resource).resourceType &&
+            (resource as Retrieved<Resource>).id
+          ) {
+            FhirQueryKeys.invalidateQueries(
+              fhirQueryContext.clientKey,
+              fhirQueryContext.queryClient,
+              (resource as Resource).resourceType,
+              (resource as Retrieved<Resource>).id,
+            );
+          }
         }
       }
       options?.mutation?.onSuccess?.(data, variables, context);

--- a/packages/query/src/r4b/index.test.tsx
+++ b/packages/query/src/r4b/index.test.tsx
@@ -24,6 +24,7 @@ import {
   FhirQueryProvider,
   useFhirBatchMutation,
   useFhirCapabilities,
+  useFhirClientMutation,
   useFhirClientQueryContext,
   useFhirCreateMutation,
   useFhirCreateOrMutation,
@@ -1102,6 +1103,28 @@ describe("hooks", () => {
             ],
           } satisfies Partial<ListOrganizationsQuery>);
         });
+      });
+    });
+
+    it("client", async () => {
+      const { result } = renderHook(
+        () => useFhirClientMutation<Organization>(),
+        {
+          wrapper,
+        },
+      );
+
+      result.current.mutate(async (client) => {
+        return await client.update(
+          build("Organization", {
+            id: "a942b3d5-19bc-4959-8b5d-f9aedd790a94",
+          }),
+        );
+      });
+
+      await waitFor(() => {
+        expect(result.current.isSuccess).toBeTruthy();
+        expect(result.current.data?.resourceType).toEqual("Organization");
       });
     });
   });

--- a/packages/query/src/r4b/index.test.tsx
+++ b/packages/query/src/r4b/index.test.tsx
@@ -24,6 +24,7 @@ import {
   FhirQueryProvider,
   useFhirBatchMutation,
   useFhirCapabilities,
+  useFhirClient,
   useFhirClientMutation,
   useFhirClientQueryContext,
   useFhirCreateMutation,
@@ -859,6 +860,28 @@ describe("hooks", () => {
             },
           ],
         } satisfies Partial<ListOrganizationsQuery>);
+      });
+    });
+
+    it("client", async () => {
+      const { result } = renderHook(
+        () =>
+          useFhirClient(
+            async (client) =>
+              await client.read(
+                "Patient",
+                "a942b3d5-19bc-4959-8b5d-f9aedd790a94",
+              ),
+          ),
+        { wrapper },
+      );
+
+      await waitFor(() => {
+        expect(result.current.isSuccess).toBeTruthy();
+        expect(result.current.data).toMatchObject({
+          resourceType: "Patient",
+          id: "a942b3d5-19bc-4959-8b5d-f9aedd790a94",
+        });
       });
     });
   });

--- a/packages/query/src/r5/cache-keys.ts
+++ b/packages/query/src/r5/cache-keys.ts
@@ -129,6 +129,9 @@ export const FhirQueryKeys = {
       operation.parameters,
     ] as const,
 
+  clientFn: (clientKey: string, fn: string, params: unknown[]) =>
+    [clientKey, "client", fn, ...params] as const,
+
   /**
    * Invalidate all queries that might be impacted by a change on a resource.
    */
@@ -159,5 +162,6 @@ export const FhirQueryKeys = {
     queryClient.invalidateQueries({
       queryKey: [clientKey, type, undefined, "execute"],
     });
+    queryClient.invalidateQueries({ queryKey: [clientKey, "client"] });
   },
 };

--- a/packages/query/src/r5/cache-keys.ts
+++ b/packages/query/src/r5/cache-keys.ts
@@ -138,6 +138,11 @@ export const FhirQueryKeys = {
     type: AnyResourceType | undefined,
     id: string | undefined,
   ) => {
+    if (!type && !id) {
+      queryClient.invalidateQueries({ queryKey: [clientKey] });
+      return;
+    }
+
     queryClient.invalidateQueries({ queryKey: [clientKey, type, id] });
     queryClient.invalidateQueries({ queryKey: [clientKey, type, "search"] });
     queryClient.invalidateQueries({

--- a/packages/query/src/r5/hooks/index.ts
+++ b/packages/query/src/r5/hooks/index.ts
@@ -1,5 +1,6 @@
 export * from "./use-fhir-batch-mutation";
 export * from "./use-fhir-capabilities";
+export * from "./use-fhir-client";
 export * from "./use-fhir-client-mutation";
 export * from "./use-fhir-create-mutation";
 export * from "./use-fhir-create-or-mutation";

--- a/packages/query/src/r5/hooks/index.ts
+++ b/packages/query/src/r5/hooks/index.ts
@@ -1,5 +1,6 @@
 export * from "./use-fhir-batch-mutation";
 export * from "./use-fhir-capabilities";
+export * from "./use-fhir-client-mutation";
 export * from "./use-fhir-create-mutation";
 export * from "./use-fhir-create-or-mutation";
 export * from "./use-fhir-delete-mutation";

--- a/packages/query/src/r5/hooks/use-fhir-client-mutation.tsx
+++ b/packages/query/src/r5/hooks/use-fhir-client-mutation.tsx
@@ -1,0 +1,69 @@
+import { FhirClient } from "@bonfhir/core/r5";
+import {
+  UseMutationOptions,
+  UseMutationResult,
+  useMutation,
+} from "@tanstack/react-query";
+import { FhirQueryKeys } from "../cache-keys";
+import { useFhirClientQueryContext } from "../context";
+
+export type UseFhirClientMutationArgs<TResult> = (
+  client: FhirClient,
+) => Promise<TResult>;
+
+export interface UseFhirClientMutationOptions<TResult> {
+  /** The FhirClient key to use to perform the query. */
+  fhirClient?: string | null | undefined;
+  mutation?:
+    | Omit<
+        UseMutationOptions<
+          TResult,
+          unknown,
+          UseFhirClientMutationArgs<TResult>,
+          unknown
+        >,
+        "mutationFn"
+      >
+    | null
+    | undefined;
+  /**
+   * Whether to invalidate all queries that use the same FhirClient.
+   * IF true, you should probably think about doing manual invalidation in the `onSuccess` callback.
+   */
+  doNotInvalidateAllQueries?: boolean;
+}
+
+/**
+ * This hook allows you to perform one or several operations using a FhirClient directly.
+ *
+ * Invoking it will invalidate all queries that use the same FhirClient if `manageCache` is true (the default).
+ */
+export function useFhirClientMutation<TResult = unknown>(
+  options?: UseFhirClientMutationOptions<TResult> | null | undefined,
+): UseMutationResult<
+  TResult,
+  unknown,
+  UseFhirClientMutationArgs<TResult>,
+  unknown
+> {
+  const fhirQueryContext = useFhirClientQueryContext(options?.fhirClient);
+
+  return useMutation({
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    ...(options?.mutation as any),
+    onSuccess: (data, variables, context) => {
+      if (fhirQueryContext.manageCache && !options?.doNotInvalidateAllQueries) {
+        FhirQueryKeys.invalidateQueries(
+          fhirQueryContext.clientKey,
+          fhirQueryContext.queryClient,
+          undefined,
+          undefined,
+        );
+      }
+      options?.mutation?.onSuccess?.(data, variables, context);
+    },
+    mutationFn: async (args) => {
+      return await args(fhirQueryContext.fhirClient);
+    },
+  });
+}

--- a/packages/query/src/r5/hooks/use-fhir-client.tsx
+++ b/packages/query/src/r5/hooks/use-fhir-client.tsx
@@ -1,0 +1,47 @@
+import { FhirClient } from "@bonfhir/core/r5";
+import {
+  UseQueryOptions,
+  UseQueryResult,
+  useQuery,
+} from "@tanstack/react-query";
+import { FhirQueryKeys } from "../cache-keys";
+import { useFhirClientQueryContext } from "../context";
+
+export interface UseFhirClientOptions<TResult> {
+  /** The FhirClient key to use to perform the query. */
+  fhirClient?: string | null | undefined;
+  query?:
+    | Omit<
+        UseQueryOptions<
+          TResult,
+          unknown,
+          TResult,
+          ReturnType<(typeof FhirQueryKeys)["clientFn"]>
+        >,
+        "initialData" | "queryKey" | "queryFn"
+      >
+    | null
+    | undefined;
+}
+
+/**
+ * Return a [Query](https://tanstack.com/query/latest/docs/react/guides/queries) using a FhirClient directly.
+ */
+export function useFhirClient<TResult>(
+  fn: (client: FhirClient) => Promise<TResult>,
+  params?: unknown[],
+  options?: UseFhirClientOptions<TResult> | null | undefined,
+): UseQueryResult<TResult> {
+  const fhirQueryContext = useFhirClientQueryContext(options?.fhirClient);
+
+  return useQuery<TResult>({
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    ...(options?.query as any),
+    queryKey: FhirQueryKeys.clientFn(
+      fhirQueryContext.clientKey,
+      fn.toString(),
+      params || [],
+    ),
+    queryFn: async () => await fn(fhirQueryContext.fhirClient),
+  });
+}

--- a/packages/query/src/r5/hooks/use-fhir-transaction-mutation.tsx
+++ b/packages/query/src/r5/hooks/use-fhir-transaction-mutation.tsx
@@ -48,17 +48,19 @@ export function useFhirTransactionMutation(
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     ...(options?.mutation as any),
     onSuccess: (data, variables, context) => {
-      for (const resource of data.futureRequests.map((x) => x.resource)) {
-        if (
-          (resource as Resource).resourceType &&
-          (resource as Retrieved<Resource>).id
-        ) {
-          FhirQueryKeys.invalidateQueries(
-            fhirQueryContext.clientKey,
-            fhirQueryContext.queryClient,
-            (resource as Resource).resourceType,
-            (resource as Retrieved<Resource>).id,
-          );
+      if (fhirQueryContext.manageCache) {
+        for (const resource of data.futureRequests.map((x) => x.resource)) {
+          if (
+            (resource as Resource).resourceType &&
+            (resource as Retrieved<Resource>).id
+          ) {
+            FhirQueryKeys.invalidateQueries(
+              fhirQueryContext.clientKey,
+              fhirQueryContext.queryClient,
+              (resource as Resource).resourceType,
+              (resource as Retrieved<Resource>).id,
+            );
+          }
         }
       }
       options?.mutation?.onSuccess?.(data, variables, context);

--- a/packages/query/src/r5/index.test.tsx
+++ b/packages/query/src/r5/index.test.tsx
@@ -24,6 +24,7 @@ import {
   FhirQueryProvider,
   useFhirBatchMutation,
   useFhirCapabilities,
+  useFhirClientMutation,
   useFhirClientQueryContext,
   useFhirCreateMutation,
   useFhirCreateOrMutation,
@@ -1102,6 +1103,28 @@ describe("hooks", () => {
             ],
           } satisfies Partial<ListOrganizationsQuery>);
         });
+      });
+    });
+
+    it("client", async () => {
+      const { result } = renderHook(
+        () => useFhirClientMutation<Organization>(),
+        {
+          wrapper,
+        },
+      );
+
+      result.current.mutate(async (client) => {
+        return await client.update(
+          build("Organization", {
+            id: "a942b3d5-19bc-4959-8b5d-f9aedd790a94",
+          }),
+        );
+      });
+
+      await waitFor(() => {
+        expect(result.current.isSuccess).toBeTruthy();
+        expect(result.current.data?.resourceType).toEqual("Organization");
       });
     });
   });

--- a/packages/query/src/r5/index.test.tsx
+++ b/packages/query/src/r5/index.test.tsx
@@ -24,6 +24,7 @@ import {
   FhirQueryProvider,
   useFhirBatchMutation,
   useFhirCapabilities,
+  useFhirClient,
   useFhirClientMutation,
   useFhirClientQueryContext,
   useFhirCreateMutation,
@@ -859,6 +860,28 @@ describe("hooks", () => {
             },
           ],
         } satisfies Partial<ListOrganizationsQuery>);
+      });
+    });
+
+    it("client", async () => {
+      const { result } = renderHook(
+        () =>
+          useFhirClient(
+            async (client) =>
+              await client.read(
+                "Patient",
+                "a942b3d5-19bc-4959-8b5d-f9aedd790a94",
+              ),
+          ),
+        { wrapper },
+      );
+
+      await waitFor(() => {
+        expect(result.current.isSuccess).toBeTruthy();
+        expect(result.current.data).toMatchObject({
+          resourceType: "Patient",
+          id: "a942b3d5-19bc-4959-8b5d-f9aedd790a94",
+        });
       });
     });
   });


### PR DESCRIPTION
These two hooks are more low-level and adresses use cases where access to the client is necessary, or when there is a need to perform multiple, maybe conditional, requests.

Fix #226
Fix #58