### PR TITLE
Add FhirError component to Gluestack-ui renderer

### DIFF
--- a/.changeset/nine-parrots-explain.md
+++ b/.changeset/nine-parrots-explain.md
@@ -1,0 +1,5 @@
+---
+"@bonfhir/gluestack-ui": patch
+---
+
+Add FhirError component to gluestack-ui renderer

--- a/packages/gluestack-ui/package.json
+++ b/packages/gluestack-ui/package.json
@@ -66,6 +66,7 @@
     "@bonfhir/eslint-plugin": "workspace:*",
     "@bonfhir/prettier-config": "workspace:*",
     "@bonfhir/typescript-config": "workspace:*",
+    "@gluestack-ui/config": "^1.0.13",
     "@gluestack-ui/themed": "^1.0.37",
     "@rollup/plugin-commonjs": "^25.0.7",
     "@rollup/plugin-node-resolve": "^15.2.3",

--- a/packages/gluestack-ui/rollup.config.mjs
+++ b/packages/gluestack-ui/rollup.config.mjs
@@ -27,7 +27,7 @@ export default ["r4b", "r5"].flatMap((release) =>
       external: (id) =>
         id.startsWith("@bonfhir/") ||
         Object.keys(packageJson.peerDependencies || {}).some((x) =>
-          id.startsWith(x)
+          id.startsWith(x),
         ),
       plugins: [
         replace({
@@ -46,7 +46,9 @@ export default ["r4b", "r5"].flatMap((release) =>
           declaration: true,
           declarationDir: "dts",
           declarationMap: false,
-          exclude: ["**/*.test.ts"],
+          // Having the gluestack declaration file explode typescript currently.
+          // WE exclude it and ignore the consequent warnings.
+          exclude: ["**/*.test.ts", "**/gluestack.d.ts"],
         }),
         terser({
           compress: false,
@@ -60,7 +62,7 @@ export default ["r4b", "r5"].flatMap((release) =>
             mkdirSync(`./dist/${release}/${format}`, { recursive: true });
             writeFileSync(
               `./dist/${release}/${format}/package.json`,
-              `{"type": "${format === "cjs" ? "commonjs" : "module"}"}`
+              `{"type": "${format === "cjs" ? "commonjs" : "module"}"}`,
             );
           },
         },
@@ -68,6 +70,8 @@ export default ["r4b", "r5"].flatMap((release) =>
       ],
       onwarn(warning, warn) {
         if (["THIS_IS_UNDEFINED", "CIRCULAR_DEPENDENCY"].includes(warning.code))
+          return;
+        if (warning.toString().includes("@rollup/plugin-typescript TS2322"))
           return;
         warn(warning);
       },
@@ -104,5 +108,5 @@ export default ["r4b", "r5"].flatMap((release) =>
         warn(warning);
       },
     },
-  ])
+  ]),
 );

--- a/packages/gluestack-ui/src/r4b/feedback/fhir-error.tsx
+++ b/packages/gluestack-ui/src/r4b/feedback/fhir-error.tsx
@@ -1,0 +1,74 @@
+import { FhirErrorRendererProps } from "@bonfhir/react/r4b";
+import {
+  Alert,
+  AlertIcon,
+  Box,
+  Button,
+  ButtonIcon,
+  HStack,
+  IButtonProps,
+  InfoIcon,
+  RepeatIcon,
+  Text,
+  VStack,
+} from "@gluestack-ui/themed";
+import { ComponentProps, ReactElement } from "react";
+
+type AlertProps = ComponentProps<typeof Alert>;
+
+export function GlueStackFhirError(
+  props: FhirErrorRendererProps<GlueStackFhirErrorProps>,
+): ReactElement | null {
+  if (!props.error) {
+    return <></>;
+  }
+
+  return (
+    <Alert style={props.style} action="error" {...props.rendererProps?.alert}>
+      <HStack>
+        <VStack
+          alignItems="flex-start"
+          justifyContent="flex-start"
+          pt="$1"
+          pl="$2"
+        >
+          <AlertIcon as={InfoIcon} />
+        </VStack>
+        <VStack px="$4">
+          <Text color="red" fontWeight="$bold">
+            {props.rendererProps?.titleText ?? "Something went wrong."}
+          </Text>
+          <Text pt="$2" pb="$3">
+            {props.error.message}
+          </Text>
+          <Box alignItems="flex-start">
+            {Boolean(props.onRetry) &&
+              (props.rendererProps?.retry?.(props) ?? (
+                <Button
+                  size="sm"
+                  variant="outline"
+                  onPress={() => props.onRetry?.()}
+                  action="negative"
+                  {...props.rendererProps?.retryButton}
+                >
+                  {props.rendererProps?.retryIcon || (
+                    <ButtonIcon as={RepeatIcon} />
+                  )}
+                </Button>
+              ))}
+          </Box>
+        </VStack>
+      </HStack>
+    </Alert>
+  );
+}
+
+export interface GlueStackFhirErrorProps {
+  alert?: AlertProps | null | undefined;
+  titleText?: string | null | undefined;
+  retry?: (
+    props: FhirErrorRendererProps<GlueStackFhirErrorProps>,
+  ) => ReactElement | null | undefined;
+  retryButton?: IButtonProps | null | undefined;
+  retryIcon?: ReactElement | null | undefined;
+}

--- a/packages/gluestack-ui/src/r4b/feedback/index.ts
+++ b/packages/gluestack-ui/src/r4b/feedback/index.ts
@@ -1,0 +1,1 @@
+export * from "./fhir-error";

--- a/packages/gluestack-ui/src/r4b/gluestack.d.ts
+++ b/packages/gluestack-ui/src/r4b/gluestack.d.ts
@@ -1,0 +1,15 @@
+import {
+  IComponents,
+  IConfig,
+  componentsConfig,
+  gluestackUIConfig,
+} from "@gluestack-ui/config";
+
+declare module "@gluestack-ui/themed" {
+  interface UIConfig
+    extends Omit<typeof gluestackUIConfig, keyof IConfig>,
+      IConfig {}
+  interface UIComponents
+    extends Omit<typeof componentsConfig, keyof IComponents>,
+      IComponents {}
+}

--- a/packages/gluestack-ui/src/r4b/index.ts
+++ b/packages/gluestack-ui/src/r4b/index.ts
@@ -1,2 +1,3 @@
 export * from "./data-display/index";
+export * from "./feedback/index";
 export * from "./renderer";

--- a/packages/gluestack-ui/src/r4b/renderer.ts
+++ b/packages/gluestack-ui/src/r4b/renderer.ts
@@ -1,8 +1,9 @@
 import { FhirUIRenderer } from "@bonfhir/react/r4b";
 
 import { GlueStackFhirValue } from "./data-display/index";
+import { GlueStackFhirError } from "./feedback/index";
 
 export const GluestackUIRenderer: Partial<FhirUIRenderer> = {
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
   FhirValue: GlueStackFhirValue,
+  FhirError: GlueStackFhirError,
 };

--- a/packages/gluestack-ui/src/r5/feedback/fhir-error.tsx
+++ b/packages/gluestack-ui/src/r5/feedback/fhir-error.tsx
@@ -1,0 +1,74 @@
+import { FhirErrorRendererProps } from "@bonfhir/react/r5";
+import {
+  Alert,
+  AlertIcon,
+  Box,
+  Button,
+  ButtonIcon,
+  HStack,
+  IButtonProps,
+  InfoIcon,
+  RepeatIcon,
+  Text,
+  VStack,
+} from "@gluestack-ui/themed";
+import { ComponentProps, ReactElement } from "react";
+
+type AlertProps = ComponentProps<typeof Alert>;
+
+export function GlueStackFhirError(
+  props: FhirErrorRendererProps<GlueStackFhirErrorProps>,
+): ReactElement | null {
+  if (!props.error) {
+    return <></>;
+  }
+
+  return (
+    <Alert style={props.style} action="error" {...props.rendererProps?.alert}>
+      <HStack>
+        <VStack
+          alignItems="flex-start"
+          justifyContent="flex-start"
+          pt="$1"
+          pl="$2"
+        >
+          <AlertIcon as={InfoIcon} />
+        </VStack>
+        <VStack px="$4">
+          <Text color="red" fontWeight="$bold">
+            {props.rendererProps?.titleText ?? "Something went wrong."}
+          </Text>
+          <Text pt="$2" pb="$3">
+            {props.error.message}
+          </Text>
+          <Box alignItems="flex-start">
+            {Boolean(props.onRetry) &&
+              (props.rendererProps?.retry?.(props) ?? (
+                <Button
+                  size="sm"
+                  variant="outline"
+                  onPress={() => props.onRetry?.()}
+                  action="negative"
+                  {...props.rendererProps?.retryButton}
+                >
+                  {props.rendererProps?.retryIcon || (
+                    <ButtonIcon as={RepeatIcon} />
+                  )}
+                </Button>
+              ))}
+          </Box>
+        </VStack>
+      </HStack>
+    </Alert>
+  );
+}
+
+export interface GlueStackFhirErrorProps {
+  alert?: AlertProps | null | undefined;
+  titleText?: string | null | undefined;
+  retry?: (
+    props: FhirErrorRendererProps<GlueStackFhirErrorProps>,
+  ) => ReactElement | null | undefined;
+  retryButton?: IButtonProps | null | undefined;
+  retryIcon?: ReactElement | null | undefined;
+}

--- a/packages/gluestack-ui/src/r5/feedback/index.ts
+++ b/packages/gluestack-ui/src/r5/feedback/index.ts
@@ -1,0 +1,1 @@
+export * from "./fhir-error";

--- a/packages/gluestack-ui/src/r5/gluestack.d.ts
+++ b/packages/gluestack-ui/src/r5/gluestack.d.ts
@@ -1,0 +1,15 @@
+import {
+  IComponents,
+  IConfig,
+  componentsConfig,
+  gluestackUIConfig,
+} from "@gluestack-ui/config";
+
+declare module "@gluestack-ui/themed" {
+  interface UIConfig
+    extends Omit<typeof gluestackUIConfig, keyof IConfig>,
+      IConfig {}
+  interface UIComponents
+    extends Omit<typeof componentsConfig, keyof IComponents>,
+      IComponents {}
+}

--- a/packages/gluestack-ui/src/r5/index.ts
+++ b/packages/gluestack-ui/src/r5/index.ts
@@ -1,2 +1,3 @@
 export * from "./data-display/index";
+export * from "./feedback/index";
 export * from "./renderer";

--- a/packages/gluestack-ui/src/r5/renderer.ts
+++ b/packages/gluestack-ui/src/r5/renderer.ts
@@ -1,8 +1,9 @@
 import { FhirUIRenderer } from "@bonfhir/react/r5";
 
 import { GlueStackFhirValue } from "./data-display/index";
+import { GlueStackFhirError } from "./feedback/index";
 
 export const GluestackUIRenderer: Partial<FhirUIRenderer> = {
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
   FhirValue: GlueStackFhirValue,
+  FhirError: GlueStackFhirError,
 };

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -26,7 +26,7 @@ importers:
         version: 2.27.1
       '@graphql-codegen/cli':
         specifier: ^5.0.0
-        version: 5.0.0(@parcel/watcher@2.3.0)(@types/node@20.11.5)(graphql@16.8.1)(typescript@5.3.3)
+        version: 5.0.0(@parcel/watcher@2.4.0)(@types/node@20.11.5)(graphql@16.8.1)(typescript@5.3.3)
       graphql:
         specifier: ^16.8.1
         version: 16.8.1
@@ -693,7 +693,7 @@ importers:
         version: 16.8.1
       jest:
         specifier: ^29.7.0
-        version: 29.7.0(@types/node@20.11.5)
+        version: 29.7.0(@types/node@20.11.5)(ts-node@10.9.2)
       jest-mock-extended:
         specifier: ^3.0.5
         version: 3.0.5(jest@29.7.0)(typescript@5.3.3)
@@ -873,6 +873,9 @@ importers:
       '@bonfhir/typescript-config':
         specifier: workspace:*
         version: link:../typescript-config
+      '@gluestack-ui/config':
+        specifier: ^1.0.13
+        version: 1.0.13(@gluestack-style/react@1.0.41)(@gluestack-ui/themed@1.0.37)
       '@gluestack-ui/themed':
         specifier: ^1.0.37
         version: 1.0.37(@gluestack-style/react@1.0.41)(@types/react-native@0.73.0)(expo@50.0.2)(nativewind@2.0.11)(react-dom@18.2.0)(react-native-svg@14.1.0)(react-native-web@0.19.10)(react-native@0.73.2)(react@18.2.0)
@@ -1172,7 +1175,7 @@ importers:
         version: 0.5.0(esbuild@0.19.11)
       jest:
         specifier: ^29.7.0
-        version: 29.7.0(@types/node@20.11.5)
+        version: 29.7.0(@types/node@20.11.5)(ts-node@10.9.2)
       jest-environment-jsdom:
         specifier: ^29.7.0
         version: 29.7.0
@@ -7490,6 +7493,16 @@ packages:
       - react-native
     dev: true
 
+  /@gluestack-ui/config@1.0.13(@gluestack-style/react@1.0.41)(@gluestack-ui/themed@1.0.37):
+    resolution: {integrity: sha512-7ASOJLtXdKHNwFKW4uQXV2QpMtDTVF6d31wOp5RWH7SUlX9308l/WkeXXIS4VwIUKD6LIbkFIQZXGSamr8y9dA==}
+    peerDependencies:
+      '@gluestack-style/react': '>=1.0'
+      '@gluestack-ui/themed': '>=1.0.20'
+    dependencies:
+      '@gluestack-style/react': 1.0.41
+      '@gluestack-ui/themed': 1.0.37(@gluestack-style/react@1.0.41)(@types/react-native@0.73.0)(expo@50.0.2)(nativewind@2.0.11)(react-dom@18.2.0)(react-native-svg@14.1.0)(react-native-web@0.19.10)(react-native@0.73.2)(react@18.2.0)
+    dev: true
+
   /@gluestack-ui/divider@0.1.8(react-dom@18.2.0)(react@18.2.0):
     resolution: {integrity: sha512-l+OQ1XD5qI20ghxKbpi+pqntRtd0mtkmhfXYLODbjt2eec3U9kpV1xawXpfN/TFd45WWZTpEQ616sOQqFLo3RA==}
     peerDependencies:
@@ -7985,63 +7998,6 @@ packages:
       '@graphql-codegen/plugin-helpers': 3.1.2(graphql@16.8.1)
       graphql: 16.8.1
       tslib: 2.4.1
-    dev: true
-
-  /@graphql-codegen/cli@5.0.0(@parcel/watcher@2.3.0)(@types/node@20.11.5)(graphql@16.8.1)(typescript@5.3.3):
-    resolution: {integrity: sha512-A7J7+be/a6e+/ul2KI5sfJlpoqeqwX8EzktaKCeduyVKgOLA6W5t+NUGf6QumBDXU8PEOqXk3o3F+RAwCWOiqA==}
-    hasBin: true
-    peerDependencies:
-      '@parcel/watcher': ^2.1.0
-      graphql: ^0.8.0 || ^0.9.0 || ^0.10.0 || ^0.11.0 || ^0.12.0 || ^0.13.0 || ^14.0.0 || ^15.0.0 || ^16.0.0
-    peerDependenciesMeta:
-      '@parcel/watcher':
-        optional: true
-    dependencies:
-      '@babel/generator': 7.23.6
-      '@babel/template': 7.22.15
-      '@babel/types': 7.23.6
-      '@graphql-codegen/core': 4.0.0(graphql@16.8.1)
-      '@graphql-codegen/plugin-helpers': 5.0.1(graphql@16.8.1)
-      '@graphql-tools/apollo-engine-loader': 8.0.0(graphql@16.8.1)
-      '@graphql-tools/code-file-loader': 8.0.2(graphql@16.8.1)
-      '@graphql-tools/git-loader': 8.0.2(graphql@16.8.1)
-      '@graphql-tools/github-loader': 8.0.0(@types/node@20.11.5)(graphql@16.8.1)
-      '@graphql-tools/graphql-file-loader': 8.0.0(graphql@16.8.1)
-      '@graphql-tools/json-file-loader': 8.0.0(graphql@16.8.1)
-      '@graphql-tools/load': 8.0.0(graphql@16.8.1)
-      '@graphql-tools/prisma-loader': 8.0.1(@types/node@20.11.5)(graphql@16.8.1)
-      '@graphql-tools/url-loader': 8.0.0(@types/node@20.11.5)(graphql@16.8.1)
-      '@graphql-tools/utils': 10.0.7(graphql@16.8.1)
-      '@parcel/watcher': 2.3.0
-      '@whatwg-node/fetch': 0.8.8
-      chalk: 4.1.2
-      cosmiconfig: 8.3.6(typescript@5.3.3)
-      debounce: 1.2.1
-      detect-indent: 6.1.0
-      graphql: 16.8.1
-      graphql-config: 5.0.3(@types/node@20.11.5)(graphql@16.8.1)(typescript@5.3.3)
-      inquirer: 8.2.6
-      is-glob: 4.0.3
-      jiti: 1.21.0
-      json-to-pretty-yaml: 1.2.2
-      listr2: 4.0.5
-      log-symbols: 4.1.0
-      micromatch: 4.0.5
-      shell-quote: 1.8.1
-      string-env-interpolation: 1.0.1
-      ts-log: 2.2.5
-      tslib: 2.6.2
-      yaml: 2.3.4
-      yargs: 17.7.2
-    transitivePeerDependencies:
-      - '@types/node'
-      - bufferutil
-      - cosmiconfig-toml-loader
-      - encoding
-      - enquirer
-      - supports-color
-      - typescript
-      - utf-8-validate
     dev: true
 
   /@graphql-codegen/cli@5.0.0(@parcel/watcher@2.4.0)(@types/node@20.11.5)(graphql@16.8.1)(typescript@5.3.3):
@@ -9113,49 +9069,6 @@ packages:
       - utf-8-validate
     dev: true
 
-  /@jest/core@29.7.0:
-    resolution: {integrity: sha512-n7aeXWKMnGtDA48y8TLWJPJmLmmZ642Ceo78cYWEpiD7FzDgmNDV/GCVRorPABdXLJZ/9wzzgZAlHjXjxDHGsg==}
-    engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
-    peerDependencies:
-      node-notifier: ^8.0.1 || ^9.0.0 || ^10.0.0
-    peerDependenciesMeta:
-      node-notifier:
-        optional: true
-    dependencies:
-      '@jest/console': 29.7.0
-      '@jest/reporters': 29.7.0
-      '@jest/test-result': 29.7.0
-      '@jest/transform': 29.7.0
-      '@jest/types': 29.6.3
-      '@types/node': 20.11.5
-      ansi-escapes: 4.3.2
-      chalk: 4.1.2
-      ci-info: 3.9.0
-      exit: 0.1.2
-      graceful-fs: 4.2.11
-      jest-changed-files: 29.7.0
-      jest-config: 29.7.0(@types/node@20.11.5)
-      jest-haste-map: 29.7.0
-      jest-message-util: 29.7.0
-      jest-regex-util: 29.6.3
-      jest-resolve: 29.7.0
-      jest-resolve-dependencies: 29.7.0
-      jest-runner: 29.7.0
-      jest-runtime: 29.7.0
-      jest-snapshot: 29.7.0
-      jest-util: 29.7.0
-      jest-validate: 29.7.0
-      jest-watcher: 29.7.0
-      micromatch: 4.0.5
-      pretty-format: 29.7.0
-      slash: 3.0.0
-      strip-ansi: 6.0.1
-    transitivePeerDependencies:
-      - babel-plugin-macros
-      - supports-color
-      - ts-node
-    dev: true
-
   /@jest/core@29.7.0(ts-node@10.9.2):
     resolution: {integrity: sha512-n7aeXWKMnGtDA48y8TLWJPJmLmmZ642Ceo78cYWEpiD7FzDgmNDV/GCVRorPABdXLJZ/9wzzgZAlHjXjxDHGsg==}
     engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
@@ -10094,15 +10007,6 @@ packages:
     resolution: {integrity: sha512-dhPeilub1NuIG0X5Kvhh9lH4iW3ZsHlnzwgwbOlgwQ2wG1IqFzsgHqmKPk3WzsdWAeaxKJxgM0+W433RmN45GA==}
     dev: false
 
-  /@parcel/watcher-android-arm64@2.3.0:
-    resolution: {integrity: sha512-f4o9eA3dgk0XRT3XhB0UWpWpLnKgrh1IwNJKJ7UJek7eTYccQ8LR7XUWFKqw6aEq5KUNlCcGvSzKqSX/vtWVVA==}
-    engines: {node: '>= 10.0.0'}
-    cpu: [arm64]
-    os: [android]
-    requiresBuild: true
-    dev: true
-    optional: true
-
   /@parcel/watcher-android-arm64@2.4.0:
     resolution: {integrity: sha512-+fPtO/GsbYX1LJnCYCaDVT3EOBjvSFdQN9Mrzh9zWAOOfvidPWyScTrHIZHHfJBvlHzNA0Gy0U3NXFA/M7PHUA==}
     engines: {node: '>= 10.0.0'}
@@ -10112,28 +10016,10 @@ packages:
     dev: true
     optional: true
 
-  /@parcel/watcher-darwin-arm64@2.3.0:
-    resolution: {integrity: sha512-mKY+oijI4ahBMc/GygVGvEdOq0L4DxhYgwQqYAz/7yPzuGi79oXrZG52WdpGA1wLBPrYb0T8uBaGFo7I6rvSKw==}
-    engines: {node: '>= 10.0.0'}
-    cpu: [arm64]
-    os: [darwin]
-    requiresBuild: true
-    dev: true
-    optional: true
-
   /@parcel/watcher-darwin-arm64@2.4.0:
     resolution: {integrity: sha512-T/At5pansFuQ8VJLRx0C6C87cgfqIYhW2N/kBfLCUvDhCah0EnLLwaD/6MW3ux+rpgkpQAnMELOCTKlbwncwiA==}
     engines: {node: '>= 10.0.0'}
     cpu: [arm64]
-    os: [darwin]
-    requiresBuild: true
-    dev: true
-    optional: true
-
-  /@parcel/watcher-darwin-x64@2.3.0:
-    resolution: {integrity: sha512-20oBj8LcEOnLE3mgpy6zuOq8AplPu9NcSSSfyVKgfOhNAc4eF4ob3ldj0xWjGGbOF7Dcy1Tvm6ytvgdjlfUeow==}
-    engines: {node: '>= 10.0.0'}
-    cpu: [x64]
     os: [darwin]
     requiresBuild: true
     dev: true
@@ -10148,29 +10034,11 @@ packages:
     dev: true
     optional: true
 
-  /@parcel/watcher-freebsd-x64@2.3.0:
-    resolution: {integrity: sha512-7LftKlaHunueAEiojhCn+Ef2CTXWsLgTl4hq0pkhkTBFI3ssj2bJXmH2L67mKpiAD5dz66JYk4zS66qzdnIOgw==}
-    engines: {node: '>= 10.0.0'}
-    cpu: [x64]
-    os: [freebsd]
-    requiresBuild: true
-    dev: true
-    optional: true
-
   /@parcel/watcher-freebsd-x64@2.4.0:
     resolution: {integrity: sha512-dHTRMIplPDT1M0+BkXjtMN+qLtqq24sLDUhmU+UxxLP2TEY2k8GIoqIJiVrGWGomdWsy5IO27aDV1vWyQ6gfHA==}
     engines: {node: '>= 10.0.0'}
     cpu: [x64]
     os: [freebsd]
-    requiresBuild: true
-    dev: true
-    optional: true
-
-  /@parcel/watcher-linux-arm-glibc@2.3.0:
-    resolution: {integrity: sha512-1apPw5cD2xBv1XIHPUlq0cO6iAaEUQ3BcY0ysSyD9Kuyw4MoWm1DV+W9mneWI+1g6OeP6dhikiFE6BlU+AToTQ==}
-    engines: {node: '>= 10.0.0'}
-    cpu: [arm]
-    os: [linux]
     requiresBuild: true
     dev: true
     optional: true
@@ -10184,26 +10052,8 @@ packages:
     dev: true
     optional: true
 
-  /@parcel/watcher-linux-arm64-glibc@2.3.0:
-    resolution: {integrity: sha512-mQ0gBSQEiq1k/MMkgcSB0Ic47UORZBmWoAWlMrTW6nbAGoLZP+h7AtUM7H3oDu34TBFFvjy4JCGP43JlylkTQA==}
-    engines: {node: '>= 10.0.0'}
-    cpu: [arm64]
-    os: [linux]
-    requiresBuild: true
-    dev: true
-    optional: true
-
   /@parcel/watcher-linux-arm64-glibc@2.4.0:
     resolution: {integrity: sha512-QuJTAQdsd7PFW9jNGaV9Pw+ZMWV9wKThEzzlY3Lhnnwy7iW23qtQFPql8iEaSFMCVI5StNNmONUopk+MFKpiKg==}
-    engines: {node: '>= 10.0.0'}
-    cpu: [arm64]
-    os: [linux]
-    requiresBuild: true
-    dev: true
-    optional: true
-
-  /@parcel/watcher-linux-arm64-musl@2.3.0:
-    resolution: {integrity: sha512-LXZAExpepJew0Gp8ZkJ+xDZaTQjLHv48h0p0Vw2VMFQ8A+RKrAvpFuPVCVwKJCr5SE+zvaG+Etg56qXvTDIedw==}
     engines: {node: '>= 10.0.0'}
     cpu: [arm64]
     os: [linux]
@@ -10220,26 +10070,8 @@ packages:
     dev: true
     optional: true
 
-  /@parcel/watcher-linux-x64-glibc@2.3.0:
-    resolution: {integrity: sha512-P7Wo91lKSeSgMTtG7CnBS6WrA5otr1K7shhSjKHNePVmfBHDoAOHYRXgUmhiNfbcGk0uMCHVcdbfxtuiZCHVow==}
-    engines: {node: '>= 10.0.0'}
-    cpu: [x64]
-    os: [linux]
-    requiresBuild: true
-    dev: true
-    optional: true
-
   /@parcel/watcher-linux-x64-glibc@2.4.0:
     resolution: {integrity: sha512-KphV8awJmxU3q52JQvJot0QMu07CIyEjV+2Tb2ZtbucEgqyRcxOBDMsqp1JNq5nuDXtcCC0uHQICeiEz38dPBQ==}
-    engines: {node: '>= 10.0.0'}
-    cpu: [x64]
-    os: [linux]
-    requiresBuild: true
-    dev: true
-    optional: true
-
-  /@parcel/watcher-linux-x64-musl@2.3.0:
-    resolution: {integrity: sha512-+kiRE1JIq8QdxzwoYY+wzBs9YbJ34guBweTK8nlzLKimn5EQ2b2FSC+tAOpq302BuIMjyuUGvBiUhEcLIGMQ5g==}
     engines: {node: '>= 10.0.0'}
     cpu: [x64]
     os: [linux]
@@ -10256,28 +10088,10 @@ packages:
     dev: true
     optional: true
 
-  /@parcel/watcher-win32-arm64@2.3.0:
-    resolution: {integrity: sha512-35gXCnaz1AqIXpG42evcoP2+sNL62gZTMZne3IackM+6QlfMcJLy3DrjuL6Iks7Czpd3j4xRBzez3ADCj1l7Aw==}
-    engines: {node: '>= 10.0.0'}
-    cpu: [arm64]
-    os: [win32]
-    requiresBuild: true
-    dev: true
-    optional: true
-
   /@parcel/watcher-win32-arm64@2.4.0:
     resolution: {integrity: sha512-NOej2lqlq8bQNYhUMnOD0nwvNql8ToQF+1Zhi9ULZoG+XTtJ9hNnCFfyICxoZLXor4bBPTOnzs/aVVoefYnjIg==}
     engines: {node: '>= 10.0.0'}
     cpu: [arm64]
-    os: [win32]
-    requiresBuild: true
-    dev: true
-    optional: true
-
-  /@parcel/watcher-win32-ia32@2.3.0:
-    resolution: {integrity: sha512-FJS/IBQHhRpZ6PiCjFt1UAcPr0YmCLHRbTc00IBTrelEjlmmgIVLeOx4MSXzx2HFEy5Jo5YdhGpxCuqCyDJ5ow==}
-    engines: {node: '>= 10.0.0'}
-    cpu: [ia32]
     os: [win32]
     requiresBuild: true
     dev: true
@@ -10292,15 +10106,6 @@ packages:
     dev: true
     optional: true
 
-  /@parcel/watcher-win32-x64@2.3.0:
-    resolution: {integrity: sha512-dLx+0XRdMnVI62kU3wbXvbIRhLck4aE28bIGKbRGS7BJNt54IIj9+c/Dkqb+7DJEbHUZAX1bwaoM8PqVlHJmCA==}
-    engines: {node: '>= 10.0.0'}
-    cpu: [x64]
-    os: [win32]
-    requiresBuild: true
-    dev: true
-    optional: true
-
   /@parcel/watcher-win32-x64@2.4.0:
     resolution: {integrity: sha512-pAUyUVjfFjWaf/pShmJpJmNxZhbMvJASUpdes9jL6bTEJ+gDxPRSpXTIemNyNsb9AtbiGXs9XduP1reThmd+dA==}
     engines: {node: '>= 10.0.0'}
@@ -10309,29 +10114,6 @@ packages:
     requiresBuild: true
     dev: true
     optional: true
-
-  /@parcel/watcher@2.3.0:
-    resolution: {integrity: sha512-pW7QaFiL11O0BphO+bq3MgqeX/INAk9jgBldVDYjlQPO4VddoZnF22TcF9onMhnLVHuNqBJeRf+Fj7eezi/+rQ==}
-    engines: {node: '>= 10.0.0'}
-    dependencies:
-      detect-libc: 1.0.3
-      is-glob: 4.0.3
-      micromatch: 4.0.5
-      node-addon-api: 7.0.0
-    optionalDependencies:
-      '@parcel/watcher-android-arm64': 2.3.0
-      '@parcel/watcher-darwin-arm64': 2.3.0
-      '@parcel/watcher-darwin-x64': 2.3.0
-      '@parcel/watcher-freebsd-x64': 2.3.0
-      '@parcel/watcher-linux-arm-glibc': 2.3.0
-      '@parcel/watcher-linux-arm64-glibc': 2.3.0
-      '@parcel/watcher-linux-arm64-musl': 2.3.0
-      '@parcel/watcher-linux-x64-glibc': 2.3.0
-      '@parcel/watcher-linux-x64-musl': 2.3.0
-      '@parcel/watcher-win32-arm64': 2.3.0
-      '@parcel/watcher-win32-ia32': 2.3.0
-      '@parcel/watcher-win32-x64': 2.3.0
-    dev: true
 
   /@parcel/watcher@2.4.0:
     resolution: {integrity: sha512-XJLGVL0DEclX5pcWa2N9SX1jCGTDd8l972biNooLFtjneuGqodupPQh6XseXIBBeVIMaaJ7bTcs3qGvXwsp4vg==}
@@ -18734,25 +18516,6 @@ packages:
       readable-stream: 3.6.2
     dev: true
 
-  /create-jest@29.7.0(@types/node@20.11.5):
-    resolution: {integrity: sha512-Adz2bdH0Vq3F53KEMJOoftQFutWCukm6J24wbPWRO4k1kMY7gS7ds/uoJkNuV8wDCtWWnuwGcJwpWcih+zEW1Q==}
-    engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
-    hasBin: true
-    dependencies:
-      '@jest/types': 29.6.3
-      chalk: 4.1.2
-      exit: 0.1.2
-      graceful-fs: 4.2.11
-      jest-config: 29.7.0(@types/node@20.11.5)
-      jest-util: 29.7.0
-      prompts: 2.4.2
-    transitivePeerDependencies:
-      - '@types/node'
-      - babel-plugin-macros
-      - supports-color
-      - ts-node
-    dev: true
-
   /create-jest@29.7.0(@types/node@20.11.5)(ts-node@10.9.2):
     resolution: {integrity: sha512-Adz2bdH0Vq3F53KEMJOoftQFutWCukm6J24wbPWRO4k1kMY7gS7ds/uoJkNuV8wDCtWWnuwGcJwpWcih+zEW1Q==}
     engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
@@ -23785,34 +23548,6 @@ packages:
       - utf-8-validate
     dev: true
 
-  /jest-cli@29.7.0(@types/node@20.11.5):
-    resolution: {integrity: sha512-OVVobw2IubN/GSYsxETi+gOe7Ka59EFMR/twOU3Jb2GnKKeMGJB5SGUUrEz3SFVmJASUdZUzy83sLNNQ2gZslg==}
-    engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
-    hasBin: true
-    peerDependencies:
-      node-notifier: ^8.0.1 || ^9.0.0 || ^10.0.0
-    peerDependenciesMeta:
-      node-notifier:
-        optional: true
-    dependencies:
-      '@jest/core': 29.7.0
-      '@jest/test-result': 29.7.0
-      '@jest/types': 29.6.3
-      chalk: 4.1.2
-      create-jest: 29.7.0(@types/node@20.11.5)
-      exit: 0.1.2
-      import-local: 3.1.0
-      jest-config: 29.7.0(@types/node@20.11.5)
-      jest-util: 29.7.0
-      jest-validate: 29.7.0
-      yargs: 17.7.2
-    transitivePeerDependencies:
-      - '@types/node'
-      - babel-plugin-macros
-      - supports-color
-      - ts-node
-    dev: true
-
   /jest-cli@29.7.0(@types/node@20.11.5)(ts-node@10.9.2):
     resolution: {integrity: sha512-OVVobw2IubN/GSYsxETi+gOe7Ka59EFMR/twOU3Jb2GnKKeMGJB5SGUUrEz3SFVmJASUdZUzy83sLNNQ2gZslg==}
     engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
@@ -23879,46 +23614,6 @@ packages:
       - canvas
       - supports-color
       - utf-8-validate
-    dev: true
-
-  /jest-config@29.7.0(@types/node@20.11.5):
-    resolution: {integrity: sha512-uXbpfeQ7R6TZBqI3/TxCU4q4ttk3u0PJeC+E0zbfSoSjq6bJ7buBPxzQPL0ifrkY4DNu4JUdk0ImlBUYi840eQ==}
-    engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
-    peerDependencies:
-      '@types/node': '*'
-      ts-node: '>=9.0.0'
-    peerDependenciesMeta:
-      '@types/node':
-        optional: true
-      ts-node:
-        optional: true
-    dependencies:
-      '@babel/core': 7.23.6
-      '@jest/test-sequencer': 29.7.0
-      '@jest/types': 29.6.3
-      '@types/node': 20.11.5
-      babel-jest: 29.7.0(@babel/core@7.23.6)
-      chalk: 4.1.2
-      ci-info: 3.9.0
-      deepmerge: 4.3.1
-      glob: 7.2.3
-      graceful-fs: 4.2.11
-      jest-circus: 29.7.0
-      jest-environment-node: 29.7.0
-      jest-get-type: 29.6.3
-      jest-regex-util: 29.6.3
-      jest-resolve: 29.7.0
-      jest-runner: 29.7.0
-      jest-util: 29.7.0
-      jest-validate: 29.7.0
-      micromatch: 4.0.5
-      parse-json: 5.2.0
-      pretty-format: 29.7.0
-      slash: 3.0.0
-      strip-json-comments: 3.1.1
-    transitivePeerDependencies:
-      - babel-plugin-macros
-      - supports-color
     dev: true
 
   /jest-config@29.7.0(@types/node@20.11.5)(ts-node@10.9.2):
@@ -24265,7 +23960,7 @@ packages:
       jest: ^24.0.0 || ^25.0.0 || ^26.0.0 || ^27.0.0 || ^28.0.0 || ^29.0.0
       typescript: ^3.0.0 || ^4.0.0 || ^5.0.0 || 5
     dependencies:
-      jest: 29.7.0(@types/node@20.11.5)
+      jest: 29.7.0(@types/node@20.11.5)(ts-node@10.9.2)
       ts-essentials: 7.0.3(typescript@5.3.3)
       typescript: 5.3.3
     dev: true
@@ -24760,27 +24455,6 @@ packages:
       - supports-color
       - ts-node
       - utf-8-validate
-    dev: true
-
-  /jest@29.7.0(@types/node@20.11.5):
-    resolution: {integrity: sha512-NIy3oAFp9shda19hy4HK0HRTWKtPJmGdnvywu01nOqNC2vZg+Z+fvJDxpMQA88eb2I9EcafcdjYgsDthnYTvGw==}
-    engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
-    hasBin: true
-    peerDependencies:
-      node-notifier: ^8.0.1 || ^9.0.0 || ^10.0.0
-    peerDependenciesMeta:
-      node-notifier:
-        optional: true
-    dependencies:
-      '@jest/core': 29.7.0
-      '@jest/types': 29.6.3
-      import-local: 3.1.0
-      jest-cli: 29.7.0(@types/node@20.11.5)
-    transitivePeerDependencies:
-      - '@types/node'
-      - babel-plugin-macros
-      - supports-color
-      - ts-node
     dev: true
 
   /jest@29.7.0(@types/node@20.11.5)(ts-node@10.9.2):
@@ -27272,10 +26946,6 @@ packages:
 
   /node-abort-controller@3.1.1:
     resolution: {integrity: sha512-AGK2yQKIjRuqnc6VkX2Xj5d+QW8xZ87pa1UK6yA6ouUyuxfHuMP6umE5QK7UmTeOAymo+Zx1Fxiuw9rVx8taHQ==}
-    dev: true
-
-  /node-addon-api@7.0.0:
-    resolution: {integrity: sha512-vgbBJTS4m5/KkE16t5Ly0WW9hz46swAstv0hYYwMtbG7AznRhNyfLRe8HZAiWIpcHzoO7HxhLuBQj9rJ/Ho0ZA==}
     dev: true
 
   /node-addon-api@7.1.0:


### PR DESCRIPTION
#180

- Alert component does not follow Gluestack-ui docs exactly because the Alert component is not meant to have buttons, so I made built it to support the retry button.
- Note: We should add a line in the future Gluestack docs that we require the use of the `  <GluestackUIProvider config={gluestackUIConfig}>` provider, because this FhirError component is using props that exist only on the styled version of the components (e.g Alert prop action is a styled prop) If we want to support unstyled gluestack components, then we'll have to build things diffferently. I'll add this to the Issue

<img width="387" alt="Screenshot 2024-01-19 at 9 47 33 AM" src="https://github.com/bonfhir/bonfhir/assets/8885263/ea099b9e-dc0c-4c65-bbb2-51eea4b356da">
<img width="381" alt="Screenshot 2024-01-19 at 9 48 08 AM" src="https://github.com/bonfhir/bonfhir/assets/8885263/ce738f87-5667-40de-bd91-971cfbaa270b">
