### PR TITLE
Add FhirQueryLoader component to Gluestack-ui render

### DIFF
--- a/.changeset/afraid-pumpkins-happen.md
+++ b/.changeset/afraid-pumpkins-happen.md
@@ -1,0 +1,5 @@
+---
+"@bonfhir/gluestack-ui": patch
+---
+
+Add FhirQueryLoader component to Gluestack-ui render

--- a/packages/gluestack-ui/src/r4b/feedback/fhir-query-loader.tsx
+++ b/packages/gluestack-ui/src/r4b/feedback/fhir-query-loader.tsx
@@ -1,0 +1,62 @@
+import {
+  FhirError,
+  FhirErrorProps,
+  FhirQueryLoaderRendererProps,
+} from "@bonfhir/react/r4b";
+import { Box, Center, Spinner } from "@gluestack-ui/themed";
+import { ComponentProps, ReactElement } from "react";
+
+type BoxProps = ComponentProps<typeof Box>;
+type CenterProps = ComponentProps<typeof Center>;
+type SpinnerProps = ComponentProps<typeof Spinner>;
+
+export function GlueStackFhirQueryLoader(
+  props: FhirQueryLoaderRendererProps<GlueStackFhirQueryLoaderProps>,
+): ReactElement | null {
+  if (props.isLoading) {
+    return (
+      <Center style={props.style} {...props.rendererProps?.center}>
+        {props.loader || (
+          <Spinner size="large" {...props.rendererProps?.spinner} />
+        )}
+      </Center>
+    );
+  }
+
+  if (props.isError) {
+    console.error(props.errors);
+    return (
+      <Box style={props.style} {...props.rendererProps?.box}>
+        {props.errors.map((error, index) =>
+          props.error ? (
+            props.error(error)
+          ) : (
+            <FhirError
+              key={index}
+              error={error}
+              onRetry={
+                props.allowRetry === undefined || props.allowRetry
+                  ? () => props.retry()
+                  : undefined
+              }
+              {...props.rendererProps?.error}
+            />
+          ),
+        )}
+      </Box>
+    );
+  }
+
+  return (
+    <Box style={props.style} {...props.rendererProps?.box}>
+      {props.children}
+    </Box>
+  );
+}
+
+export interface GlueStackFhirQueryLoaderProps {
+  box?: BoxProps | null | undefined;
+  center?: CenterProps | null | undefined;
+  spinner?: SpinnerProps | null | undefined;
+  error?: FhirErrorProps | null | undefined;
+}

--- a/packages/gluestack-ui/src/r4b/feedback/index.ts
+++ b/packages/gluestack-ui/src/r4b/feedback/index.ts
@@ -1,1 +1,2 @@
 export * from "./fhir-error";
+export * from "./fhir-query-loader";

--- a/packages/gluestack-ui/src/r4b/renderer.ts
+++ b/packages/gluestack-ui/src/r4b/renderer.ts
@@ -1,9 +1,10 @@
 import { FhirUIRenderer } from "@bonfhir/react/r4b";
 
 import { GlueStackFhirValue } from "./data-display/index";
-import { GlueStackFhirError } from "./feedback/index";
+import { GlueStackFhirError, GlueStackFhirQueryLoader } from "./feedback/index";
 
 export const GluestackUIRenderer: Partial<FhirUIRenderer> = {
   FhirValue: GlueStackFhirValue,
   FhirError: GlueStackFhirError,
+  FhirQueryLoader: GlueStackFhirQueryLoader,
 };

--- a/packages/gluestack-ui/src/r5/feedback/fhir-query-loader.tsx
+++ b/packages/gluestack-ui/src/r5/feedback/fhir-query-loader.tsx
@@ -1,0 +1,62 @@
+import {
+  FhirError,
+  FhirErrorProps,
+  FhirQueryLoaderRendererProps,
+} from "@bonfhir/react/r5";
+import { Box, Center, Spinner } from "@gluestack-ui/themed";
+import { ComponentProps, ReactElement } from "react";
+
+type BoxProps = ComponentProps<typeof Box>;
+type CenterProps = ComponentProps<typeof Center>;
+type SpinnerProps = ComponentProps<typeof Spinner>;
+
+export function GlueStackFhirQueryLoader(
+  props: FhirQueryLoaderRendererProps<GlueStackFhirQueryLoaderProps>,
+): ReactElement | null {
+  if (props.isLoading) {
+    return (
+      <Center style={props.style} {...props.rendererProps?.center}>
+        {props.loader || (
+          <Spinner size="large" {...props.rendererProps?.spinner} />
+        )}
+      </Center>
+    );
+  }
+
+  if (props.isError) {
+    console.error(props.errors);
+    return (
+      <Box style={props.style} {...props.rendererProps?.box}>
+        {props.errors.map((error, index) =>
+          props.error ? (
+            props.error(error)
+          ) : (
+            <FhirError
+              key={index}
+              error={error}
+              onRetry={
+                props.allowRetry === undefined || props.allowRetry
+                  ? () => props.retry()
+                  : undefined
+              }
+              {...props.rendererProps?.error}
+            />
+          ),
+        )}
+      </Box>
+    );
+  }
+
+  return (
+    <Box style={props.style} {...props.rendererProps?.box}>
+      {props.children}
+    </Box>
+  );
+}
+
+export interface GlueStackFhirQueryLoaderProps {
+  box?: BoxProps | null | undefined;
+  center?: CenterProps | null | undefined;
+  spinner?: SpinnerProps | null | undefined;
+  error?: FhirErrorProps | null | undefined;
+}

--- a/packages/gluestack-ui/src/r5/feedback/index.ts
+++ b/packages/gluestack-ui/src/r5/feedback/index.ts
@@ -1,1 +1,2 @@
 export * from "./fhir-error";
+export * from "./fhir-query-loader";

--- a/packages/gluestack-ui/src/r5/renderer.ts
+++ b/packages/gluestack-ui/src/r5/renderer.ts
@@ -1,9 +1,10 @@
 import { FhirUIRenderer } from "@bonfhir/react/r5";
 
 import { GlueStackFhirValue } from "./data-display/index";
-import { GlueStackFhirError } from "./feedback/index";
+import { GlueStackFhirError, GlueStackFhirQueryLoader } from "./feedback/index";
 
 export const GluestackUIRenderer: Partial<FhirUIRenderer> = {
   FhirValue: GlueStackFhirValue,
   FhirError: GlueStackFhirError,
+  FhirQueryLoader: GlueStackFhirQueryLoader,
 };


### PR DESCRIPTION
#181 

Note: one strange thing I noticed is that the spinner coming in from the themed library is different to what it looks like in the docs, so I am not sure what is going on with that.

![Screenshot 2024-01-23 at 8 53 04 AM](https://github.com/bonfhir/bonfhir/assets/8885263/008fecad-60b1-4d98-8af9-950e23d41819)
