### PR TITLE
Better n8n trigger

### DIFF
--- a/.changeset/gorgeous-lobsters-sing.md
+++ b/.changeset/gorgeous-lobsters-sing.md
@@ -1,0 +1,5 @@
+---
+"@bonfhir/n8n-nodes-bonfhir": minor
+---
+
+Better error handling and management

--- a/.changeset/happy-lamps-swim.md
+++ b/.changeset/happy-lamps-swim.md
@@ -1,0 +1,5 @@
+---
+"@bonfhir/n8n-nodes-bonfhir": minor
+---
+
+Introduce trigger modes - webhook or resthook to handle different styles of servers, and have HAPI FHIR compatibility.

--- a/docs/website/packages/n8n/triggers.md
+++ b/docs/website/packages/n8n/triggers.md
@@ -18,3 +18,25 @@ The creation of the subscription is managed automatically by the node, and is cr
 
 ![Add bonFHIR Trigger](/img/docs/n8n/add-bonfhir-trigger.png)
 ![CR received output](/img/docs/n8n/cr-received-output.png)
+
+## Modes
+
+The trigger has 2 modes: Webhook or Resthook
+
+### Webhook
+
+In this mode, the trigger behaves like a standard webhook:
+
+- listen for POST requests
+- only listen at the root of the webhook URL (A unique path prefix is generated to avoid potential collisions)
+
+This is the mode that servers like [Medplum](https://medplum.com) expect.
+
+### Resthook
+
+In Resthook mode, the trigger behaves closer to what a "real" FHIR server would do:
+
+- listen for PUT requests
+- expect a resource type and resource id to be appended in the path
+
+This is the mode that servers like [HAPI FHIR](https://hapifhir.io/) expect.


### PR DESCRIPTION
This PR exists to make the subscription trigger compatible with HAPI.

It introduces a "mode" that can be selected that changes the behavior of the webhook.

Also, the webhook now responds with its own payload, to simulate what a FHIR server would do in any cases.

This PR also enhances error management in the node itself with better error detection and messages.