### PR TITLE
Make subscriptions compatible with HAPI as well as Medplum (accept PUT and POST requests).

### DIFF
--- a/.changeset/breezy-stingrays-lie.md
+++ b/.changeset/breezy-stingrays-lie.md
@@ -1,0 +1,8 @@
+---
+"@bonfhir/subscriptions": minor
+"@bonfhir/aws-lambda": minor
+"@bonfhir/next": minor
+"@bonfhir/cli": minor
+---
+
+Make subscriptions compatible with HAPI as well as Medplum (accept PUT and POST requests).

--- a/apps/sample-lambda/serverless.yml
+++ b/apps/sample-lambda/serverless.yml
@@ -12,6 +12,9 @@ functions:
       - httpApi:
           path: /fhir/subscriptions/{endpoint+}
           method: post
+      - httpApi:
+          path: /fhir/subscriptions/{endpoint+}
+          method: put
 
 plugins:
   - serverless-esbuild

--- a/apps/sample-lambda/src/subscriptions/communication-requests.ts
+++ b/apps/sample-lambda/src/subscriptions/communication-requests.ts
@@ -2,7 +2,7 @@ import { CommunicationRequest } from "@bonfhir/core/r4b";
 import { FhirSubscription } from "@bonfhir/subscriptions/r4b";
 
 export const communicationRequests: FhirSubscription<CommunicationRequest> = {
-  criteria: "CommunicationRequest",
+  criteria: "CommunicationRequest?",
   reason: "Send communication requests",
   endpoint: "communication-requests",
   async handler({ resource, logger }) {

--- a/docs/website/packages/subscriptions/subscription-handlers.md
+++ b/docs/website/packages/subscriptions/subscription-handlers.md
@@ -5,7 +5,7 @@ description: React to FHIR Resources changes
 ---
 
 At the heart of the bonFHIR subscription models lies the concept of a `FhirSubscription`.  
-A `FhirSubscription` is an abstraction that represents both the criterias that trigger it (the registration information),
+A `FhirSubscription` is an abstraction that represents both the criteria that trigger it (the registration information),
 and the handler that gets executed when said subscription is triggered.
 
 ## Basic usage

--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
     "@graphql-codegen/cli": "^5.0.0",
     "graphql": "^16.8.1",
     "graphql-config": "^5.0.3",
-    "turbo": "^1.12.3"
+    "turbo": "^1.12.5"
   },
   "pnpm": {
     "overrides": {

--- a/packages/aws-lambda/src/r4b/handler.ts
+++ b/packages/aws-lambda/src/r4b/handler.ts
@@ -61,7 +61,9 @@ export function fhirSubscriptionHandler(
       };
     }
 
-    const endpoint = event.pathParameters?.["endpoint"];
+    const endpoint = event.pathParameters?.["endpoint"]
+      ?.split("/")
+      .find(Boolean);
 
     if (!endpoint) {
       return {
@@ -131,7 +133,7 @@ export function fhirSubscriptionHandler(
     const resource = JSON.parse(event.body);
 
     try {
-      const result = await subscription.handler({
+      await subscription.handler({
         fhirClient:
           typeof config.fhirClient === "function"
             ? await config.fhirClient()
@@ -140,13 +142,11 @@ export function fhirSubscriptionHandler(
         logger,
       });
 
-      return result == undefined
-        ? { statusCode: 204 }
-        : {
-            statusCode: 200,
-            body: JSON.stringify(result),
-            headers: { "Content-Type": "application/json" },
-          };
+      return {
+        statusCode: 200,
+        body: JSON.stringify(resource),
+        headers: { "Content-Type": "application/fhir+json" },
+      };
     } catch (error) {
       logger.error(error);
 

--- a/packages/aws-lambda/src/r5/handler.ts
+++ b/packages/aws-lambda/src/r5/handler.ts
@@ -61,7 +61,9 @@ export function fhirSubscriptionHandler(
       };
     }
 
-    const endpoint = event.pathParameters?.["endpoint"];
+    const endpoint = event.pathParameters?.["endpoint"]
+      ?.split("/")
+      .find(Boolean);
 
     if (!endpoint) {
       return {
@@ -131,7 +133,7 @@ export function fhirSubscriptionHandler(
     const resource = JSON.parse(event.body);
 
     try {
-      const result = await subscription.handler({
+      await subscription.handler({
         fhirClient:
           typeof config.fhirClient === "function"
             ? await config.fhirClient()
@@ -140,13 +142,11 @@ export function fhirSubscriptionHandler(
         logger,
       });
 
-      return result == undefined
-        ? { statusCode: 204 }
-        : {
-            statusCode: 200,
-            body: JSON.stringify(result),
-            headers: { "Content-Type": "application/json" },
-          };
+      return {
+        statusCode: 200,
+        body: JSON.stringify(resource),
+        headers: { "Content-Type": "application/fhir+json" },
+      };
     } catch (error) {
       logger.error(error);
 

--- a/packages/cli/src/templates/lambda.ts
+++ b/packages/cli/src/templates/lambda.ts
@@ -237,6 +237,9 @@ functions:
       - httpApi:
           path: /fhir/subscriptions/{endpoint+}
           method: post
+      - httpApi:
+          path: /fhir/subscriptions/{endpoint+}
+          method: post
 
 plugins:
   - serverless-esbuild

--- a/packages/next/src/r4b/server/subscriptions/middleware.ts
+++ b/packages/next/src/r4b/server/subscriptions/middleware.ts
@@ -60,7 +60,10 @@ export function fhirSubscriptions(
         ? await config.fhirClient()
         : config.fhirClient;
 
-    const action = request.nextUrl.pathname.split("/").at(-1);
+    const action = request.nextUrl.pathname
+      .split(config.prefix)[1]
+      ?.split("/")
+      .find(Boolean);
 
     if (action === "register") {
       try {
@@ -100,7 +103,7 @@ export function fhirSubscriptions(
 
     const resource = await request.json();
     try {
-      const result = await subscription.handler({
+      await subscription.handler({
         fhirClient:
           typeof config.fhirClient === "function"
             ? await config.fhirClient()
@@ -109,16 +112,12 @@ export function fhirSubscriptions(
         logger,
       });
 
-      return result == undefined
-        ? new NextResponse(undefined, {
-            status: 204,
-          })
-        : new NextResponse(JSON.stringify(result), {
-            status: 200,
-            headers: {
-              "Content-Type": "application/json",
-            },
-          });
+      return new NextResponse(JSON.stringify(resource), {
+        status: 200,
+        headers: {
+          "Content-Type": "application/fhir+json",
+        },
+      });
     } catch (error) {
       logger.error(error);
       return new NextResponse(errorToString(error), {

--- a/packages/next/src/r5/server/subscriptions/middleware.ts
+++ b/packages/next/src/r5/server/subscriptions/middleware.ts
@@ -60,7 +60,10 @@ export function fhirSubscriptions(
         ? await config.fhirClient()
         : config.fhirClient;
 
-    const action = request.nextUrl.pathname.split("/").at(-1);
+    const action = request.nextUrl.pathname
+      .split(config.prefix)[1]
+      ?.split("/")
+      .find(Boolean);
 
     if (action === "register") {
       try {
@@ -100,7 +103,7 @@ export function fhirSubscriptions(
 
     const resource = await request.json();
     try {
-      const result = await subscription.handler({
+      await subscription.handler({
         fhirClient:
           typeof config.fhirClient === "function"
             ? await config.fhirClient()
@@ -109,16 +112,12 @@ export function fhirSubscriptions(
         logger,
       });
 
-      return result == undefined
-        ? new NextResponse(undefined, {
-            status: 204,
-          })
-        : new NextResponse(JSON.stringify(result), {
-            status: 200,
-            headers: {
-              "Content-Type": "application/json",
-            },
-          });
+      return new NextResponse(JSON.stringify(resource), {
+        status: 200,
+        headers: {
+          "Content-Type": "application/fhir+json",
+        },
+      });
     } catch (error) {
       logger.error(error);
       return new NextResponse(errorToString(error), {

--- a/packages/subscriptions/src/r4b/__fhir-subscription.ts
+++ b/packages/subscriptions/src/r4b/__fhir-subscription.ts
@@ -28,9 +28,7 @@ export interface FhirSubscription<TResource extends AnyResource = AnyResource> {
 
 export type FhirSubscriptionHandler<
   TResource extends AnyResource = AnyResource,
-> = (
-  args: FhirSubscriptionHandlerArgs<TResource>,
-) => Promise<FhirSubscriptionHandlerResult>;
+> = (args: FhirSubscriptionHandlerArgs<TResource>) => Promise<void>;
 
 export type FhirSubscriptionLogger = Pick<
   typeof console,
@@ -48,12 +46,6 @@ export interface FhirSubscriptionHandlerArgs<
   /** The configured logger. */
   logger: FhirSubscriptionLogger | null | undefined;
 }
-
-export type FhirSubscriptionHandlerResult =
-  | void
-  | Promise<void>
-  | object
-  | Promise<object>;
 
 export interface RegisterSubscriptionsArgs {
   fhirClient: FhirClient;

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -35,8 +35,8 @@ importers:
         specifier: ^5.0.3
         version: 5.0.3(@types/node@20.11.5)(graphql@16.8.1)(typescript@5.3.3)
       turbo:
-        specifier: ^1.12.3
-        version: 1.12.3
+        specifier: ^1.12.5
+        version: 1.12.5
 
   apps/sample-ehr:
     dependencies:
@@ -8569,14 +8569,14 @@ packages:
       '@gluestack-style/react': 1.0.41
     dev: true
 
-  /@gluestack-style/legend-motion-animation-driver@1.0.3(@gluestack-style/react@1.0.41)(@legendapp/motion@2.2.1):
+  /@gluestack-style/legend-motion-animation-driver@1.0.3(@gluestack-style/react@1.0.41)(@legendapp/motion@2.3.0):
     resolution: {integrity: sha512-sD6aFS6Tq5XpyjrboFEIc8LrRY4TA4kodFYHzk6mDchvbkdLODijtjnaDQB1UqihOkMRg49e7ANRAOzc7eymaQ==}
     peerDependencies:
       '@gluestack-style/react': '>=1.0.27'
       '@legendapp/motion': '>=2.2'
     dependencies:
       '@gluestack-style/react': 1.0.41
-      '@legendapp/motion': 2.2.1(nativewind@2.0.11)(react-native@0.73.2)(react@18.2.0)
+      '@legendapp/motion': 2.3.0(nativewind@2.0.11)(react-native@0.73.2)(react@18.2.0)
     dev: true
 
   /@gluestack-style/react@1.0.41:
@@ -9085,7 +9085,7 @@ packages:
     dependencies:
       '@expo/html-elements': 0.9.1
       '@gluestack-style/animation-resolver': 1.0.3(@gluestack-style/react@1.0.41)
-      '@gluestack-style/legend-motion-animation-driver': 1.0.3(@gluestack-style/react@1.0.41)(@legendapp/motion@2.2.1)
+      '@gluestack-style/legend-motion-animation-driver': 1.0.3(@gluestack-style/react@1.0.41)(@legendapp/motion@2.3.0)
       '@gluestack-style/react': 1.0.41
       '@gluestack-ui/accordion': 1.0.0(react-dom@18.2.0)(react-native@0.73.2)(react@18.2.0)
       '@gluestack-ui/actionsheet': 0.2.36(react-dom@18.2.0)(react-native@0.73.2)(react@18.2.0)
@@ -9118,7 +9118,7 @@ packages:
       '@gluestack-ui/textarea': 0.1.19(react-dom@18.2.0)(react-native@0.73.2)(react@18.2.0)
       '@gluestack-ui/toast': 1.0.3(react-dom@18.2.0)(react-native@0.73.2)(react@18.2.0)
       '@gluestack-ui/tooltip': 0.1.25(react-dom@18.2.0)(react-native@0.73.2)(react@18.2.0)
-      '@legendapp/motion': 2.2.1(nativewind@2.0.11)(react-native@0.73.2)(react@18.2.0)
+      '@legendapp/motion': 2.3.0(nativewind@2.0.11)(react-native@0.73.2)(react@18.2.0)
       '@types/react-native': 0.73.0(@babel/core@7.23.9)(@babel/preset-env@7.23.9)(react@18.2.0)
       react: 18.2.0
       react-dom: 18.2.0(react@18.2.0)
@@ -10744,8 +10744,8 @@ packages:
     resolution: {integrity: sha512-GaHYm+c0O9MjZRu0ongGBRbinu8gVAMd2UZjji6jVmqKtZluZnptXGWhz1E8j8D2HJ3f/yMxKAUC0b+57wncIw==}
     dev: true
 
-  /@legendapp/motion@2.2.1(nativewind@2.0.11)(react-native@0.73.2)(react@18.2.0):
-    resolution: {integrity: sha512-kh9+05qHvBLPT+qR2XE+KzP5KgqLqaqE0aZ19xu5yxKp8X+JH7d9SHPj6W5yo5ttSzaPx0IqApYMtHDVk73FvQ==}
+  /@legendapp/motion@2.3.0(nativewind@2.0.11)(react-native@0.73.2)(react@18.2.0):
+    resolution: {integrity: sha512-LtTD06eyz/Ge23FAR6BY+i9Gsgr/ZgxE12FneML8LrZGcZOSPN2Ojz3N2eJaTiA50kqoeqrGCaYJja8KgKpL6Q==}
     peerDependencies:
       nativewind: ^2.0.0
       react: '>=16 || 18'
@@ -34901,64 +34901,64 @@ packages:
       safe-buffer: 5.2.1
     dev: true
 
-  /turbo-darwin-64@1.12.3:
-    resolution: {integrity: sha512-dDglIaux+A4jOnB9CDH69sujmrnuLJLrKw1t3J+if6ySlFuxSwC++gDq9TVuOZo2+S7lFkGh+x5ytn3wp+jE8Q==}
+  /turbo-darwin-64@1.12.5:
+    resolution: {integrity: sha512-0GZ8reftwNQgIQLHkHjHEXTc/Z1NJm+YjsrBP+qhM/7yIZ3TEy9gJhuogDt2U0xIWwFgisTyzbtU7xNaQydtoA==}
     cpu: [x64]
     os: [darwin]
     requiresBuild: true
     dev: true
     optional: true
 
-  /turbo-darwin-arm64@1.12.3:
-    resolution: {integrity: sha512-5TqqeujEyHMoVUWGzSzUl5ERSg7HDCdbU3gBs5ziWTpFRpeJ/+Y15kYyZJcMQcubRIH3Y1hL/yA5IhlGdgXOMA==}
+  /turbo-darwin-arm64@1.12.5:
+    resolution: {integrity: sha512-8WpOLNNzvH6kohQOjihD+gaWL+ZFNfjvBwhOF0rjEzvW+YR3Pa7KjhulrjWyeN2yMFqAPubTbZIGOz1EVXLuQA==}
     cpu: [arm64]
     os: [darwin]
     requiresBuild: true
     dev: true
     optional: true
 
-  /turbo-linux-64@1.12.3:
-    resolution: {integrity: sha512-yUreU+/gq4vlBtcdyfjz7slwz4zM1RG8sSXvyHmAS+QXqSrGkegg4qLl2fRbv/c3EyA/XbfcZuD6tcrXkejr6g==}
+  /turbo-linux-64@1.12.5:
+    resolution: {integrity: sha512-INit73+bNUpwqGZCxgXCR3I+cQsdkQ3/LkfkgSOibkpg+oGqxJRzeXw3sp990d7SCoE8QOcs3iw+PtiFX/LDAA==}
     cpu: [x64]
     os: [linux]
     requiresBuild: true
     dev: true
     optional: true
 
-  /turbo-linux-arm64@1.12.3:
-    resolution: {integrity: sha512-XRwAsp2eRSqZmaMVNrmHoKqofeJMuD87zmefZLTRAObh38hIwKgyl2QRsJIbteob5RN77yFbv3lAJ36UIY5h7w==}
+  /turbo-linux-arm64@1.12.5:
+    resolution: {integrity: sha512-6lkRBvxtI/GQdGtaAec9LvVQUoRw6nXFp0kM+Eu+5PbZqq7yn6cMkgDJLI08zdeui36yXhone8XGI8pHg8bpUQ==}
     cpu: [arm64]
     os: [linux]
     requiresBuild: true
     dev: true
     optional: true
 
-  /turbo-windows-64@1.12.3:
-    resolution: {integrity: sha512-CPnRfnUCtmFeShOtUdMCthySjmyHaoTyh9JueiYFvtCNeO3WfDMj63dpOQstQWHdJFYmIrIGfhAclcds9ePQYA==}
+  /turbo-windows-64@1.12.5:
+    resolution: {integrity: sha512-gQYbOhZg5Ww0bQ/bC0w/4W6yQRwBumUUnkB+QPo15VznwxZe2a7bo6JM+9Xy9dKLa/kn+p7zTqme4OEp6M3/Yg==}
     cpu: [x64]
     os: [win32]
     requiresBuild: true
     dev: true
     optional: true
 
-  /turbo-windows-arm64@1.12.3:
-    resolution: {integrity: sha512-cYA/wlzvp4vlCNHYJ2AjNS3FLXWwUC/5CJompBkTeKFFB6AviE/iLkbIhFikCVSNXZk/3AGanpMUXIkt3bdlwg==}
+  /turbo-windows-arm64@1.12.5:
+    resolution: {integrity: sha512-auvhZ9FrhnvQ4mgBlY9O68MT4dIfprYGvd2uPICba/mHUZZvVy5SGgbHJ0KbMwaJfnnFoPgLJO6M+3N2gDprKw==}
     cpu: [arm64]
     os: [win32]
     requiresBuild: true
     dev: true
     optional: true
 
-  /turbo@1.12.3:
-    resolution: {integrity: sha512-a6q8I0TK9ohACYbkmxzG/JYPuDC4VCvfmXLTlf321qQ4BIAhoyaOj/O2g+zJ6L1vNYnZ82G4LrbMfgLLngbLsg==}
+  /turbo@1.12.5:
+    resolution: {integrity: sha512-FATU5EnhrYG8RvQJYFJnDd18DpccDjyvd53hggw9T9JEg9BhWtIEoeaKtBjYbpXwOVrJQMDdXcIB4f2nD3QPPg==}
     hasBin: true
     optionalDependencies:
-      turbo-darwin-64: 1.12.3
-      turbo-darwin-arm64: 1.12.3
-      turbo-linux-64: 1.12.3
-      turbo-linux-arm64: 1.12.3
-      turbo-windows-64: 1.12.3
-      turbo-windows-arm64: 1.12.3
+      turbo-darwin-64: 1.12.5
+      turbo-darwin-arm64: 1.12.5
+      turbo-linux-64: 1.12.5
+      turbo-linux-arm64: 1.12.5
+      turbo-windows-64: 1.12.5
+      turbo-windows-arm64: 1.12.5
     dev: true
 
   /tweetnacl@0.14.5:


### PR DESCRIPTION
HAPI FHIR subscriptions resthooks are PUT requests and append the resource type and the resource id, and epxect a reply with the resource itself (as it acts as a fhir client.

This updates make the subscriptions compatible with that, on top of the existing model that was used by Medplum of POST to a stable url.