### PR TITLE
Fix-client-patch

### DIFF
--- a/.changeset/good-olives-do.md
+++ b/.changeset/good-olives-do.md
@@ -1,0 +1,6 @@
+---
+"@bonfhir/n8n-nodes-bonfhir": minor
+"@bonfhir/core": minor
+---
+
+Fix PATCH operation - now sending the proper `application/json-patch+json` content-type. This is a compatibility update for HAPI.

--- a/.changeset/old-lemons-begin.md
+++ b/.changeset/old-lemons-begin.md
@@ -1,0 +1,6 @@
+---
+"@bonfhir/cli": patch
+"create-bonfhir": patch
+---
+
+Fix lambda template - moved to any for serverless-offline, which had an issue with multiple handlers at same address.

--- a/packages/cli/src/templates/lambda.ts
+++ b/packages/cli/src/templates/lambda.ts
@@ -235,10 +235,7 @@ functions:
     events:
       - httpApi:
           path: /fhir/subscriptions/{endpoint+}
-          method: post
-      - httpApi:
-          path: /fhir/subscriptions/{endpoint+}
-          method: post
+          method: any
 
 plugins:
   - serverless-esbuild

--- a/packages/core/src/r4b/fetch-fhir-client.test.ts
+++ b/packages/core/src/r4b/fetch-fhir-client.test.ts
@@ -155,13 +155,14 @@ describe("fetch-fhir-client", () => {
       async ({ request }) => new Response(JSON.stringify(await request.json())),
     ),
 
-    http.patch(
-      `${baseUrl}/Patient/:patientId`,
-      ({ params }) =>
-        new Response(
-          JSON.stringify({ ...patientExample, id: params.patientId }),
-        ),
-    ),
+    http.patch(`${baseUrl}/Patient/:patientId`, ({ params, request }) => {
+      expect(request.headers.get("Content-Type")).toEqual(
+        "application/json-patch+json",
+      );
+      return new Response(
+        JSON.stringify({ ...patientExample, id: params.patientId }),
+      );
+    }),
 
     http.delete(`${baseUrl}/Patient/:patientId`, ({ params }) => {
       if (params.patientId === "not-found") {

--- a/packages/core/src/r4b/fetch-fhir-client.ts
+++ b/packages/core/src/r4b/fetch-fhir-client.ts
@@ -265,7 +265,11 @@ export class FetchFhirClient implements FhirClient {
       {
         method: "PATCH",
         body: JSON.stringify(normalizePatchBody(type, body)),
-        headers,
+        headers: {
+          ...headers,
+          "Content-Type":
+            headers?.["Content-Type"] ?? "application/json-patch+json",
+        },
         signal,
       },
       type,

--- a/packages/core/src/r5/fetch-fhir-client.test.ts
+++ b/packages/core/src/r5/fetch-fhir-client.test.ts
@@ -155,13 +155,14 @@ describe("fetch-fhir-client", () => {
       async ({ request }) => new Response(JSON.stringify(await request.json())),
     ),
 
-    http.patch(
-      `${baseUrl}/Patient/:patientId`,
-      ({ params }) =>
-        new Response(
-          JSON.stringify({ ...patientExample, id: params.patientId }),
-        ),
-    ),
+    http.patch(`${baseUrl}/Patient/:patientId`, ({ params, request }) => {
+      expect(request.headers.get("Content-Type")).toEqual(
+        "application/json-patch+json",
+      );
+      return new Response(
+        JSON.stringify({ ...patientExample, id: params.patientId }),
+      );
+    }),
 
     http.delete(`${baseUrl}/Patient/:patientId`, ({ params }) => {
       if (params.patientId === "not-found") {

--- a/packages/core/src/r5/fetch-fhir-client.ts
+++ b/packages/core/src/r5/fetch-fhir-client.ts
@@ -265,7 +265,11 @@ export class FetchFhirClient implements FhirClient {
       {
         method: "PATCH",
         body: JSON.stringify(normalizePatchBody(type, body)),
-        headers,
+        headers: {
+          ...headers,
+          "Content-Type":
+            headers?.["Content-Type"] ?? "application/json-patch+json",
+        },
         signal,
       },
       type,

--- a/packages/n8n-nodes-bonfhir/src/nodes/Bonfhir/Bonfhir.node.ts
+++ b/packages/n8n-nodes-bonfhir/src/nodes/Bonfhir/Bonfhir.node.ts
@@ -676,7 +676,10 @@ async function buildRequestOptions(
 
   const requestOptions: OptionsWithUri = {
     headers: {
-      "content-type": `application/fhir+json`,
+      "content-type":
+        operation === "Patch"
+          ? `application/json-patch+json`
+          : `application/fhir+json`,
     },
     uri: "",
     qs,


### PR DESCRIPTION
This PR contains 2 fixes:

- Fix the PATCH operation content-type (to `application/json-patch+json`) - this makes it compatible with HAPI, and better spec-compliant
- Fix the lambda template by removing the duplicated subscription handler, and transitioning to a 'any" method; although it was legitimate, this was making serverless-offline unhappy.