### PR TITLE
Better questionnaires

### DIFF
--- a/.changeset/brave-eels-hunt.md
+++ b/.changeset/brave-eels-hunt.md
@@ -1,0 +1,6 @@
+---
+"@bonfhir/mantine": minor
+"@bonfhir/react": minor
+---
+
+Add `onResponseChange` on `<FhirQuestionnaire />`.

--- a/.changeset/spicy-toes-dance.md
+++ b/.changeset/spicy-toes-dance.md
@@ -1,0 +1,5 @@
+---
+"@bonfhir/core": patch
+---
+
+Add questionnaire utility methods.

--- a/.changeset/wet-impalas-melt.md
+++ b/.changeset/wet-impalas-melt.md
@@ -1,0 +1,5 @@
+---
+"@bonfhir/react": patch
+---
+
+Add sort="original" option to `<FhirInput />` to keep the original terminology expansion order

--- a/packages/mantine/src/r4b/inputs/fhir-questionnaire.tsx
+++ b/packages/mantine/src/r4b/inputs/fhir-questionnaire.tsx
@@ -7,6 +7,7 @@ import {
   QuestionnaireResponse,
   QuestionnaireResponseItem,
   ValueSetExpansionContains,
+  WithRequired,
   build,
   canonical,
 } from "@bonfhir/core/r4b";
@@ -37,41 +38,6 @@ import { UseFhirFormReturnType, useFhirForm } from "../hooks/use-fhir-form";
 export function MantineFhirQuestionnaire(
   props: FhirQuestionnaireRendererProps<MantineFhirQuestionnaireProps>,
 ): ReactElement | null {
-  const form = useFhirForm<object, (values: object) => QuestionnaireResponse>({
-    transformValues(values) {
-      return build("QuestionnaireResponse", {
-        questionnaire: canonical(props.questionnaire)!,
-        status: "completed",
-        authored: new Date().toISOString(),
-        item: buildQuestionnaireResponseItems(
-          props.questionnaire!.item || [],
-          values,
-        ),
-      });
-    },
-    ...(props?.rendererProps?.form as any),
-  });
-
-  useEffect(() => {
-    if (props.isLoading) {
-      return;
-    }
-
-    if (props.questionnaire) {
-      form.setValues(
-        buildInitialValues(
-          props.questionnaire.item || [],
-          "",
-          props.questionnaireResponse?.item || [],
-        ),
-      );
-    }
-  }, [
-    props.isLoading,
-    props.questionnaire?.id,
-    props.questionnaireResponse?.id,
-  ]);
-
   if (props.isLoading || !props.questionnaire) {
     return (
       <Stack
@@ -108,6 +74,95 @@ export function MantineFhirQuestionnaire(
   }
 
   return (
+    <QuestionnaireRenderer {...props} questionnaire={props.questionnaire} />
+  );
+}
+
+export interface MantineFhirQuestionnaireProps {
+  mainStack?: StackProps | null | undefined;
+  loader?: LoaderProps | null | undefined;
+  title?: TitleProps | null | undefined;
+  itemDisplay?: FhirValueProps | null | undefined;
+  itemGroupStack?: StackProps | null | undefined;
+  itemGroupTitle?: TitleProps | null | undefined;
+  itemInput?: FhirInputProps | null | undefined;
+  submit?: ButtonProps | null | undefined;
+  submitText?: ReactNode | null | undefined;
+  cancel?: ButtonProps | null | undefined;
+  cancelText?: ReactNode | null | undefined;
+  form?:
+    | UseFormInput<any, any>
+    | ((form: UseFhirFormReturnType<any, any>) => UseFormInput<any, any>)
+    | null
+    | undefined;
+}
+
+function QuestionnaireRenderer(
+  props: WithRequired<
+    FhirQuestionnaireRendererProps<MantineFhirQuestionnaireProps>,
+    "questionnaire"
+  >,
+): ReactElement | null {
+  const form = useFhirForm<object, (values: object) => QuestionnaireResponse>({
+    transformValues(values) {
+      return build("QuestionnaireResponse", {
+        questionnaire: canonical(props.questionnaire)!,
+        status: "completed",
+        authored: new Date().toISOString(),
+        item: buildQuestionnaireResponseItems(
+          props.questionnaire.item || [],
+          values,
+        ),
+      });
+    },
+    onValuesChange(values) {
+      if (props.questionnaire && props.onResponseChange) {
+        const newValues = props.onResponseChange(
+          build("QuestionnaireResponse", {
+            questionnaire: canonical(props.questionnaire)!,
+            status: "completed",
+            authored: new Date().toISOString(),
+            item: buildQuestionnaireResponseItems(
+              props.questionnaire.item || [],
+              values,
+            ),
+          }),
+        );
+        if (newValues) {
+          form.setValues(
+            buildValues(
+              props.questionnaire.item || [],
+              "",
+              newValues.item || [],
+            ),
+          );
+        }
+      }
+    },
+    ...(props?.rendererProps?.form as any),
+  });
+
+  useEffect(() => {
+    if (props.isLoading) {
+      return;
+    }
+
+    if (props.questionnaire) {
+      form.setValues(
+        buildValues(
+          props.questionnaire.item || [],
+          "",
+          props.questionnaireResponse?.item || [],
+        ),
+      );
+    }
+  }, [
+    props.isLoading,
+    props.questionnaire?.id,
+    props.questionnaireResponse?.id,
+  ]);
+
+  return (
     <form
       onSubmit={form.onSubmit((questionnaireResponse) =>
         props.onSubmit?.(questionnaireResponse),
@@ -118,12 +173,12 @@ export function MantineFhirQuestionnaire(
         style={props.style}
         {...props.rendererProps?.mainStack}
       >
-        {props.questionnaire!.title && (
+        {props.questionnaire.title && (
           <Title order={2} {...props.rendererProps?.title}>
-            {props.questionnaire!.title}
+            {props.questionnaire.title}
           </Title>
         )}
-        {(props.questionnaire!.item || []).map((item, index) => (
+        {(props.questionnaire.item || []).map((item, index) => (
           <MantineQuestionnaireItemRenderer
             key={index}
             props={props}
@@ -149,21 +204,6 @@ export function MantineFhirQuestionnaire(
       </Stack>
     </form>
   );
-}
-
-export interface MantineFhirQuestionnaireProps {
-  mainStack?: StackProps | null | undefined;
-  loader?: LoaderProps | null | undefined;
-  title?: TitleProps | null | undefined;
-  itemDisplay?: FhirValueProps | null | undefined;
-  itemGroupStack?: StackProps | null | undefined;
-  itemGroupTitle?: TitleProps | null | undefined;
-  itemInput?: FhirInputProps | null | undefined;
-  submit?: ButtonProps | null | undefined;
-  submitText?: ReactNode | null | undefined;
-  cancel?: ButtonProps | null | undefined;
-  cancelText?: ReactNode | null | undefined;
-  form?: UseFormInput<any, any> | null | undefined;
 }
 
 function MantineQuestionnaireItemRenderer({
@@ -312,6 +352,10 @@ function buildQuestionnaireResponseItems(
       }
       case "question":
       case "display": {
+        result.push({
+          linkId: i.linkId,
+          text: i.text,
+        });
         break;
       }
       case "choice": {
@@ -349,7 +393,7 @@ function buildQuestionnaireResponseItems(
   return result.length === 0 ? undefined : result;
 }
 
-function buildInitialValues(
+function buildValues(
   item: QuestionnaireItem[],
   parentPath: string,
   responseItem: QuestionnaireResponseItem[],
@@ -361,7 +405,7 @@ function buildInitialValues(
     );
     switch (i.type) {
       case "group": {
-        result[i.linkId] = buildInitialValues(
+        result[i.linkId] = buildValues(
           i.item || [],
           concatPath(parentPath, i.linkId),
           responseI?.item || [],

--- a/packages/react/src/r4b/inputs/fhir-questionnaire.tsx
+++ b/packages/react/src/r4b/inputs/fhir-questionnaire.tsx
@@ -26,6 +26,14 @@ export interface FhirQuestionnaireProps<TRendererProps = any> {
     | undefined;
   onSubmit?: ((value: QuestionnaireResponse) => void) | null | undefined;
   onCancel?: (() => void) | null | undefined;
+  /**
+   * Invoked on every response change in the form.
+   * If the function returns a value, it will be used as the new response and the form should update.
+   * Be careful to check for infinite loops when using this function.
+   */
+  onResponseChange?: (
+    response: QuestionnaireResponse,
+  ) => QuestionnaireResponse | void | undefined;
   className?: string | undefined;
   style?: Record<string, any> | undefined;
   rendererProps?: TRendererProps;

--- a/packages/react/src/r4b/inputs/input-types/fhir-input-terminology.tsx
+++ b/packages/react/src/r4b/inputs/input-types/fhir-input-terminology.tsx
@@ -17,10 +17,13 @@ export type FhirInputTerminologyProps<TRendererProps = any> =
     placeholder?: string | null | undefined;
     fhirClient?: string | null | undefined;
     filter?: ((value: ValueSetExpansionContains) => boolean) | null | undefined;
-    sort?: (
-      a: ValueSetExpansionContains,
-      b: ValueSetExpansionContains,
-    ) => number;
+    sort?:
+      | "original"
+      | "display"
+      | ((
+          a: ValueSetExpansionContains,
+          b: ValueSetExpansionContains,
+        ) => number);
     className?: string | undefined;
     style?: Record<string, any> | undefined;
     rendererProps?: TRendererProps;
@@ -91,9 +94,33 @@ export function FhirInputTerminology<TRendererProps = any>(
       if (props.filter) {
         data = data.filter((element) => props.filter?.(element));
       }
-      data = props.sort
-        ? data.sort((a, b) => props.sort?.(a, b) || 0)
-        : data.sort(compareBy("display"));
+
+      switch (props.sort) {
+        case "original": {
+          break;
+        }
+        case "display":
+        case undefined:
+        // eslint-disable-next-line unicorn/no-null, no-fallthrough
+        case null: {
+          data = [...data].sort(compareBy("display"));
+          break;
+        }
+        default: {
+          if (typeof props.sort === "function") {
+            data = [...data].sort(
+              (a, b) =>
+                (
+                  props.sort as (
+                    a: ValueSetExpansionContains,
+                    b: ValueSetExpansionContains,
+                  ) => number
+                )?.(a, b) || 0,
+            );
+          }
+          break;
+        }
+      }
     }
 
     return render<FhirInputTerminologyRendererProps>("FhirInputTerminology", {

--- a/packages/react/src/r5/inputs/fhir-questionnaire.tsx
+++ b/packages/react/src/r5/inputs/fhir-questionnaire.tsx
@@ -26,6 +26,14 @@ export interface FhirQuestionnaireProps<TRendererProps = any> {
     | undefined;
   onSubmit?: ((value: QuestionnaireResponse) => void) | null | undefined;
   onCancel?: (() => void) | null | undefined;
+  /**
+   * Invoked on every response change in the form.
+   * If the function returns a value, it will be used as the new response and the form should update.
+   * Be careful to check for infinite loops when using this function.
+   */
+  onResponseChange?: (
+    response: QuestionnaireResponse,
+  ) => QuestionnaireResponse | void | undefined;
   className?: string | undefined;
   style?: Record<string, any> | undefined;
   rendererProps?: TRendererProps;

--- a/packages/react/src/r5/inputs/input-types/fhir-input-terminology.tsx
+++ b/packages/react/src/r5/inputs/input-types/fhir-input-terminology.tsx
@@ -17,10 +17,13 @@ export type FhirInputTerminologyProps<TRendererProps = any> =
     placeholder?: string | null | undefined;
     fhirClient?: string | null | undefined;
     filter?: ((value: ValueSetExpansionContains) => boolean) | null | undefined;
-    sort?: (
-      a: ValueSetExpansionContains,
-      b: ValueSetExpansionContains,
-    ) => number;
+    sort?:
+      | "original"
+      | "display"
+      | ((
+          a: ValueSetExpansionContains,
+          b: ValueSetExpansionContains,
+        ) => number);
     className?: string | undefined;
     style?: Record<string, any> | undefined;
     rendererProps?: TRendererProps;
@@ -91,9 +94,33 @@ export function FhirInputTerminology<TRendererProps = any>(
       if (props.filter) {
         data = data.filter((element) => props.filter?.(element));
       }
-      data = props.sort
-        ? data.sort((a, b) => props.sort?.(a, b) || 0)
-        : data.sort(compareBy("display"));
+
+      switch (props.sort) {
+        case "original": {
+          break;
+        }
+        case "display":
+        case undefined:
+        // eslint-disable-next-line unicorn/no-null, no-fallthrough
+        case null: {
+          data = [...data].sort(compareBy("display"));
+          break;
+        }
+        default: {
+          if (typeof props.sort === "function") {
+            data = [...data].sort(
+              (a, b) =>
+                (
+                  props.sort as (
+                    a: ValueSetExpansionContains,
+                    b: ValueSetExpansionContains,
+                  ) => number
+                )?.(a, b) || 0,
+            );
+          }
+          break;
+        }
+      }
     }
 
     return render<FhirInputTerminologyRendererProps>("FhirInputTerminology", {


### PR DESCRIPTION
This PR contains a couple of changes meant to better work with questionnaires:
- helper methods in core
- Adding a `onResponseChange` props to `FhirQuestionnaire` that can be used to update values dynamically
- And a sort="original" option to the `<FhirInputTerminology />` to not change the terminology sort order.