### PR TITLE
Add `@bonfhir/maintainers` to `CODEOWNERS`

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,1 +1,1 @@
-* @julienblin
+* @bonfhir/maintainers


### PR DESCRIPTION
Closes #293

This is intended to allow all members of the `@bonfhir/maintainers` team to review, accept and merge pull requests in projects where said team has been added as a maintainer.