### PR TITLE
#298: Remove use of Proxy in extendResource

### DIFF
--- a/.changeset/eighty-seas-raise.md
+++ b/.changeset/eighty-seas-raise.md
@@ -1,0 +1,5 @@
+---
+"@bonfhir/core": patch
+---
+
+Remove use of Proxy from extensions

--- a/packages/core/src/r4b/extensions.test.ts
+++ b/packages/core/src/r4b/extensions.test.ts
@@ -285,8 +285,26 @@ describe("extensions", () => {
     patient.birthSex = "OTH";
     const anotherPatient = cloneResource(patient);
     expect(anotherPatient).not.toBe(patient);
-    expect(anotherPatient.birthSex).toEqual("OTH");
     expect(anotherPatient).toBeInstanceOf(CustomPatient);
+    expect(anotherPatient).toEqual(
+      expect.objectContaining({
+        birthSex: "OTH",
+        resourceType: "Patient",
+        toFhirResource: expect.any(Function),
+        toJSON: expect.any(Function),
+        computedName: expect.any(Function),
+      }),
+    );
+  });
+
+  it("differentiation between extended resources types", () => {
+    const patient = new CustomPatient({});
+    const CustomPatientTwo = extendResource("Patient", {});
+    const patient2 = new CustomPatientTwo({});
+
+    expect(patient).toBeInstanceOf(CustomPatient);
+    expect(patient2).toBeInstanceOf(CustomPatientTwo);
+    expect(patient2).not.toBeInstanceOf(CustomPatient);
   });
 
   it("initialize with special extensions", () => {

--- a/packages/core/src/r5/extensions.test.ts
+++ b/packages/core/src/r5/extensions.test.ts
@@ -285,8 +285,26 @@ describe("extensions", () => {
     patient.birthSex = "OTH";
     const anotherPatient = cloneResource(patient);
     expect(anotherPatient).not.toBe(patient);
-    expect(anotherPatient.birthSex).toEqual("OTH");
     expect(anotherPatient).toBeInstanceOf(CustomPatient);
+    expect(anotherPatient).toEqual(
+      expect.objectContaining({
+        birthSex: "OTH",
+        resourceType: "Patient",
+        toFhirResource: expect.any(Function),
+        toJSON: expect.any(Function),
+        computedName: expect.any(Function),
+      }),
+    );
+  });
+
+  it("differentiation between extended resources types", () => {
+    const patient = new CustomPatient({});
+    const CustomPatientTwo = extendResource("Patient", {});
+    const patient2 = new CustomPatientTwo({});
+
+    expect(patient).toBeInstanceOf(CustomPatient);
+    expect(patient2).toBeInstanceOf(CustomPatientTwo);
+    expect(patient2).not.toBeInstanceOf(CustomPatient);
   });
 
   it("initialize with special extensions", () => {


### PR DESCRIPTION
# Why
https://github.com/bonfhir/bonfhir/issues/298

Remove Proxy use from extendResource. This change allows us to start moving away from class based patterns which will @bonfhir/core to be run better in all JS environments (Hermes being the target)

# What's changing
Swap out the use of Proxy in the extendResource function for a factory function. 
Based on existing tests and testing based on the documentation the behaviour of extend resources has not changed