### PR TITLE
Update `webfactory/ssh-agent` to v0.7

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -100,7 +100,7 @@ jobs:
           git-config-email: actions@github.com
 
       - name: Authenticate SSH deploy key
-        uses: webfactory/ssh-agent@v0.5.0
+        uses: webfactory/ssh-agent@v0.7.0
         with:
           ssh-private-key: ${{ secrets.GH_PAGES_DEPLOY }}
 


### PR DESCRIPTION
Updating to >= v0.6 updates the action to [use Node 16 instead of Node 12](https://github.com/webfactory/ssh-agent/blob/master/CHANGELOG.md#v060-2022-10-19) which addresses the warning we've been seeing in the CI logs.

> The following actions uses node12 which is deprecated and will be forced to run on node16: webfactory/ssh-agent@v0.5.0. For more info: https://github.blog/changelog/2023-06-13-github-actions-all-actions-will-run-on-node16-instead-of-node12-by-default/