### PR TITLE
Disable telemetry for turbo CLI

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -8,6 +8,10 @@ on:
 
 concurrency: ${{ github.workflow }}-${{ github.ref }}
 
+env:
+  DO_NOT_TRACK: 1
+  TURBO_TELEMETRY_DISABLED: 1
+
 jobs:
   build:
     if: github.event.pull_request.head.ref != 'changeset-release/main' # This should skip the build step for the Pull requests that are opened from the branch changeset-release/main.


### PR DESCRIPTION
The Turbo CLI sends usage telemetry by default without asking for consent. This change disables this telemetry-sending behavior. I've also added the informal standard DO_NOT_TRACK=1 environment variable in case any other tooling we use actually respects it.

## How do I test this?

Checking the [logs of the first build](https://github.com/bonfhir/bonfhir/actions/runs/11404960710/job/31735296313?pr=314) of this very PR and we no longer see the warning about Turbo sending telemetry.