### PR TITLE
fix: early return added to send method

### DIFF
--- a/.changeset/smart-apricots-draw.md
+++ b/.changeset/smart-apricots-draw.md
@@ -1,0 +1,5 @@
+---
+"@bonfhir/core": patch
+---
+
+fix: missing early return in batch send added

--- a/packages/core/src/r4b/bundle-executor.ts
+++ b/packages/core/src/r4b/bundle-executor.ts
@@ -417,6 +417,7 @@ export class BundleExecutor {
     if (this.request.type === "transaction") {
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
       this.response = await this.client.transaction(this.request as any);
+      return;
     }
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     this.response = await this.client.batch(this.request as any);

--- a/packages/core/src/r5/bundle-executor.ts
+++ b/packages/core/src/r5/bundle-executor.ts
@@ -417,6 +417,7 @@ export class BundleExecutor {
     if (this.request.type === "transaction") {
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
       this.response = await this.client.transaction(this.request as any);
+      return;
     }
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     this.response = await this.client.batch(this.request as any);


### PR DESCRIPTION
fix for [issue 289](https://github.com/bonfhir/bonfhir/issues/289)

# What
- batches were sent twice


# How
- early returns FTW